### PR TITLE
Add Node Name and UID to NodeReplacement Spec

### DIFF
--- a/config/crds/navarchos_v1alpha1_nodereplacement.yaml
+++ b/config/crds/navarchos_v1alpha1_nodereplacement.yaml
@@ -28,6 +28,14 @@ spec:
           type: object
         spec:
           properties:
+            nodeName:
+              description: NodeName should match the Name of the Node this NodeReplacement
+                intends to replace.
+              type: string
+            nodeUID:
+              description: NodeUID should match the UID of the Node this NodeReplacement
+                intends to replace.
+              type: string
             priority:
               description: Priority determines the priority of this NodeReplacement.
                 Higher priorities should be replaced sooner.

--- a/pkg/apis/navarchos/v1alpha1/nodereplacement_types.go
+++ b/pkg/apis/navarchos/v1alpha1/nodereplacement_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // NodeReplacementSpec defines the desired state of NodeReplacement
@@ -26,6 +27,14 @@ type NodeReplacementSpec struct {
 	// Priority determines the priority of this NodeReplacement.
 	// Higher priorities should be replaced sooner.
 	Priority *int `json:"priority,omitempty"`
+
+	// NodeName should match the Name of the Node this NodeReplacement intends to
+	// replace.
+	NodeName string `json:"nodeName,omitempty"`
+
+	// NodeUID should match the UID of the Node this NodeReplacement intends to
+	// replace.
+	NodeUID types.UID `json:"nodeUID,omitempty"`
 }
 
 // NodeReplacementPhase determines the phase in which the NodeRollout currently is

--- a/pkg/controller/noderollout/handler/handler_test.go
+++ b/pkg/controller/noderollout/handler/handler_test.go
@@ -62,6 +62,12 @@ var _ = Describe("Handler suite", func() {
 		By("with the correct priority")
 		Expect(*nr.Spec.Priority).To(Equal(priority))
 
+		By("with the correct NodeName")
+		Expect(nr.Spec.NodeName).To(Equal(owner.GetName()))
+
+		By("with the correct NodeUID")
+		Expect(nr.Spec.NodeUID).To(Equal(owner.GetUID()))
+
 		By("and an owner reference pointing to the Node")
 		Expect(nr.GetOwnerReferences()).To(ContainElement(Equal(utils.GetOwnerReferenceForNode(owner))))
 


### PR DESCRIPTION
This adds two more fields to the NodeReplacement Spec to make it easier for operators to debug failures. If the Node has gone, the operator should be able to verify that the node has gone by comparing the Node's Name and UID to the existing Nodes within the cluster