### PR TITLE
Remove Failure phases from controllers

### DIFF
--- a/config/crds/navarchos_v1alpha1_noderollout.yaml
+++ b/config/crds/navarchos_v1alpha1_noderollout.yaml
@@ -137,17 +137,6 @@ spec:
                 This is used for printing in kubectl.
               format: int64
               type: integer
-            replacementsFailed:
-              description: ReplacementsFailed lists the names of all NodeReplacements
-                that have permanently failed to replace their node.
-              items:
-                type: string
-              type: array
-            replacementsFailedCount:
-              description: ReplacementsFailedCount is the count of ReplacementsFailed.
-                This is used for printing in kubectl.
-              format: int64
-              type: integer
           required:
           - phase
           type: object

--- a/pkg/apis/navarchos/v1alpha1/nodereplacement_types.go
+++ b/pkg/apis/navarchos/v1alpha1/nodereplacement_types.go
@@ -51,7 +51,6 @@ const (
 	ReplacementPhaseNew        NodeReplacementPhase = "New"
 	ReplacementPhaseInProgress NodeReplacementPhase = "InProgress"
 	ReplacementPhaseCompleted  NodeReplacementPhase = "Completed"
-	ReplacementPhaseFailed     NodeReplacementPhase = "Failed"
 )
 
 // NodeReplacementStatus defines the observed state of NodeReplacement

--- a/pkg/apis/navarchos/v1alpha1/noderollout_types.go
+++ b/pkg/apis/navarchos/v1alpha1/noderollout_types.go
@@ -54,7 +54,6 @@ const (
 	RolloutPhaseNew        NodeRolloutPhase = "New"
 	RolloutPhaseInProgress NodeRolloutPhase = "InProgress"
 	RolloutPhaseCompleted  NodeRolloutPhase = "Completed"
-	RolloutPhaseFailed     NodeRolloutPhase = "Failed"
 )
 
 // NodeRolloutStatus defines the observed state of NodeRollout
@@ -78,14 +77,6 @@ type NodeRolloutStatus struct {
 	// ReplacementsCompletedCount is the count of ReplacementsCompleted.
 	// This is used for printing in kubectl.
 	ReplacementsCompletedCount int `json:"replacementsCompletedCount,omitempty"`
-
-	// ReplacementsFailed lists the names of all NodeReplacements that have
-	// permanently failed to replace their node.
-	ReplacementsFailed []string `json:"replacementsFailed,omitempty"`
-
-	// ReplacementsFailedCount is the count of ReplacementsFailed.
-	// This is used for printing in kubectl.
-	ReplacementsFailedCount int `json:"replacementsFailedCount,omitempty"`
 
 	// Conditions gives detailed condition information about the NodeRollout
 	Conditions []NodeReplacementCondition `json:"conditions,omitempty"`

--- a/pkg/apis/navarchos/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/navarchos/v1alpha1/zz_generated.deepcopy.go
@@ -319,11 +319,6 @@ func (in *NodeRolloutStatus) DeepCopyInto(out *NodeRolloutStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.ReplacementsFailed != nil {
-		in, out := &in.ReplacementsFailed, &out.ReplacementsFailed
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]NodeReplacementCondition, len(*in))

--- a/pkg/controller/nodereplacement/handler/handler.go
+++ b/pkg/controller/nodereplacement/handler/handler.go
@@ -10,7 +10,7 @@ import (
 
 // Options are used to configure the NodeReplacementHandler
 type Options struct {
-	// EvictionGracePeriod determins how long the controller should attempt to
+	// EvictionGracePeriod determines how long the controller should attempt to
 	// evict a pod before marking it a failed eviction
 	EvictionGracePeriod *time.Duration
 }
@@ -38,14 +38,8 @@ func NewNodeReplacementHandler(c client.Client, opts *Options) *NodeReplacementH
 	}
 }
 
-// HandleNew performs the business logic of a New NodeReplacement and returns
+// Handle performs the business logic of a NodeReplacement and returns
 // information in a Result
-func (h *NodeReplacementHandler) HandleNew(instance *navarchosv1alpha1.NodeReplacement) *status.Result {
-	return &status.Result{}
-}
-
-// HandleInProgress performs the business logic of an InProgress NodeReplacemen
-// and returns information in a Result
-func (h *NodeReplacementHandler) HandleInProgress(instance *navarchosv1alpha1.NodeReplacement) *status.Result {
+func (h *NodeReplacementHandler) Handle(instance *navarchosv1alpha1.NodeReplacement) *status.Result {
 	return &status.Result{}
 }

--- a/pkg/controller/nodereplacement/handler/handler_test.go
+++ b/pkg/controller/nodereplacement/handler/handler_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Handler suite", func() {
 
 	Context("when the Handler is called on a New NodeReplacement", func() {
 		JustBeforeEach(func() {
-			result = h.HandleNew(nodeReplacement)
+			result = h.Handle(nodeReplacement)
 		})
 
 		Context("if a another NodeReplacement is higher priority", func() {
@@ -280,7 +280,7 @@ var _ = Describe("Handler suite", func() {
 
 		// Since HandleInProgress could take some time, we set a timeout
 		JustBeforeEach(func(done Done) {
-			result = h.HandleInProgress(nodeReplacement)
+			result = h.Handle(nodeReplacement)
 			close(done)
 		}, 2*timeout.Seconds())
 

--- a/pkg/controller/noderollout/handler/handler_test.go
+++ b/pkg/controller/noderollout/handler/handler_test.go
@@ -429,25 +429,7 @@ var _ = Describe("Handler suite", func() {
 			})
 		})
 
-		Context("if a NodeReplacement has been marked as failed", func() {
-			BeforeEach(func() {
-				m.Update(nrMaster1, func(obj utils.Object) utils.Object {
-					nr, _ := obj.(*navarchosv1alpha1.NodeReplacement)
-					nr.Status.Phase = navarchosv1alpha1.ReplacementPhaseFailed
-					return nr
-				}, timeout).Should(Succeed())
-			})
-
-			It("does not set the Result ReplacementsCompleted field", func() {
-				Expect(result.ReplacementsCompleted).To(BeEmpty())
-			})
-
-			PIt("list the Failed NodeReplacement in the Result ReplacementsFailed field", func() {
-				Expect(result.ReplacementsFailed).To(ConsistOf("example-master-1"))
-			})
-		})
-
-		Context("once all NodeReplacements are marked as Completed or Failed", func() {
+		Context("once all NodeReplacements are marked as Completed", func() {
 			BeforeEach(func() {
 				for _, nr := range []*navarchosv1alpha1.NodeReplacement{nrMaster1, nrMaster2, nrWorker1, nrWorker2} {
 					m.Update(nr, func(obj utils.Object) utils.Object {
@@ -458,49 +440,17 @@ var _ = Describe("Handler suite", func() {
 				}
 			})
 
-			Context("if all NodeReplacements have been marked as Completed", func() {
-				PIt("lists the completed NodeReplacements in the Result ReplacementsCompleted field", func() {
-					Expect(result.ReplacementsCompleted).To(ConsistOf(
-						"example-master-1",
-						"example-master-2",
-						"example-worker-1",
-						"example-worker-2",
-					))
-				})
-
-				It("does not set the Result ReplacementsFailed field", func() {
-					Expect(result.ReplacementsFailed).To(BeEmpty())
-				})
-
-				PIt("sets the Result Phase field to Completed", func() {
-					Expect(result.Phase).To(Equal(navarchosv1alpha1.RolloutPhaseCompleted))
-				})
+			PIt("lists the completed NodeReplacements in the Result ReplacementsCompleted field", func() {
+				Expect(result.ReplacementsCompleted).To(ConsistOf(
+					"example-master-1",
+					"example-master-2",
+					"example-worker-1",
+					"example-worker-2",
+				))
 			})
 
-			Context("if at least one NodeReplacements have been marked as Failed", func() {
-				BeforeEach(func() {
-					m.Update(nodeReplacementFor(masterNode1), func(obj utils.Object) utils.Object {
-						nr, _ := obj.(*navarchosv1alpha1.NodeReplacement)
-						nr.Status.Phase = navarchosv1alpha1.ReplacementPhaseFailed
-						return nr
-					}, timeout).Should(Succeed())
-				})
-
-				PIt("lists the Completed NodeReplacements in the Result ReplacementsCompleted field", func() {
-					Expect(result.ReplacementsCompleted).To(ConsistOf(
-						"example-master-2",
-						"example-worker-1",
-						"example-worker-2",
-					))
-				})
-
-				PIt("lists the Failed NodeReplacements in the Result ReplacementsFailed field", func() {
-					Expect(result.ReplacementsFailed).To(ConsistOf("example-master-1"))
-				})
-
-				PIt("sets the Result Phase field to Failed", func() {
-					Expect(result.Phase).To(Equal(navarchosv1alpha1.RolloutPhaseFailed))
-				})
+			PIt("sets the Result Phase field to Completed", func() {
+				Expect(result.Phase).To(Equal(navarchosv1alpha1.RolloutPhaseCompleted))
 			})
 		})
 	})
@@ -545,48 +495,5 @@ var _ = Describe("Handler suite", func() {
 			})
 		})
 
-	})
-
-	Context("when the Handler function is called on a Failed NodeRollout", func() {
-		BeforeEach(func() {
-			m.Create(nodeReplacementFor(masterNode1)).Should(Succeed())
-			m.Create(nodeReplacementFor(masterNode2)).Should(Succeed())
-			m.Create(nodeReplacementFor(workerNode1)).Should(Succeed())
-			m.Create(nodeReplacementFor(workerNode2)).Should(Succeed())
-
-			// Set the NodeRollout as we expect it to be at this point
-			m.Update(nodeRollout, func(obj utils.Object) utils.Object {
-				nr, _ := obj.(*navarchosv1alpha1.NodeRollout)
-				nr.Status.Phase = navarchosv1alpha1.RolloutPhaseFailed
-				nr.Status.ReplacementsCreated = []string{"example-master-1", "example-master-2", "example-worker-1", "example-worker-2"}
-				nr.Status.ReplacementsCreatedCount = len(nr.Status.ReplacementsCreated)
-				nr.Status.ReplacementsCompleted = []string{"example-master-2", "example-worker-1", "example-worker-2"}
-				nr.Status.ReplacementsCompletedCount = len(nr.Status.ReplacementsCompleted)
-				nr.Status.ReplacementsFailed = []string{"example-master-1"}
-				nr.Status.ReplacementsFailedCount = len(nr.Status.ReplacementsFailed)
-				return nr
-			}, timeout).Should(Succeed())
-			Expect(nodeRollout.Status.Phase).To(Equal(navarchosv1alpha1.RolloutPhaseFailed))
-		})
-
-		JustBeforeEach(func() {
-			result = h.Handle(nodeRollout)
-		})
-
-		Context("and the NodeRollout is younger than the maximum age", func() {
-			It("does nothing", func() {
-				Expect(result).To(Equal(&status.Result{}))
-			})
-		})
-
-		Context("and the NodeRollout is older than the maximum age", func() {
-			BeforeEach(func() {
-				nodeRollout.CreationTimestamp = metav1.NewTime(time.Now().Add(h.maxAge - time.Hour))
-			})
-
-			PIt("deletes the NodeRollout", func() {
-				m.Get(nodeRollout, timeout).ShouldNot(Succeed())
-			})
-		})
 	})
 })

--- a/pkg/controller/noderollout/handler/handler_test.go
+++ b/pkg/controller/noderollout/handler/handler_test.go
@@ -180,10 +180,6 @@ var _ = Describe("Handler suite", func() {
 				Expect(result.ReplacementsCompleted).To(BeEmpty())
 			})
 
-			It("does not set the Result ReplacementsFailed field", func() {
-				Expect(result.ReplacementsFailed).To(BeEmpty())
-			})
-
 			It("does not set any error", func() {
 				Expect(result.ReplacementsCompletedError).To(BeNil())
 				Expect(result.ReplacementsCompletedReason).To(BeEmpty())
@@ -251,10 +247,6 @@ var _ = Describe("Handler suite", func() {
 				Expect(result.ReplacementsCompleted).To(BeEmpty())
 			})
 
-			It("does not set the Result ReplacementsFailed field", func() {
-				Expect(result.ReplacementsFailed).To(BeEmpty())
-			})
-
 			It("does not set any error", func() {
 				Expect(result.ReplacementsCompletedError).To(BeNil())
 				Expect(result.ReplacementsCompletedReason).To(BeEmpty())
@@ -307,10 +299,6 @@ var _ = Describe("Handler suite", func() {
 
 			It("does not set the Result ReplacementsCompleted field", func() {
 				Expect(result.ReplacementsCompleted).To(BeEmpty())
-			})
-
-			It("does not set the Result ReplacementsFailed field", func() {
-				Expect(result.ReplacementsFailed).To(BeEmpty())
 			})
 
 			It("does not set any error", func() {
@@ -405,10 +393,6 @@ var _ = Describe("Handler suite", func() {
 			It("does not set the Result ReplacementsCompleted field", func() {
 				Expect(result.ReplacementsCompleted).To(BeEmpty())
 			})
-
-			It("does not set the Result ReplacementsFailed field", func() {
-				Expect(result.ReplacementsFailed).To(BeEmpty())
-			})
 		})
 
 		Context("if a NodeReplacement has been marked as Completed", func() {
@@ -422,10 +406,6 @@ var _ = Describe("Handler suite", func() {
 
 			PIt("list the completed NodeReplacement in the Result ReplacementsCompleted field", func() {
 				Expect(result.ReplacementsCompleted).To(ConsistOf("example-master-1"))
-			})
-
-			It("does not set the Result ReplacementsFailed field", func() {
-				Expect(result.ReplacementsFailed).To(BeEmpty())
 			})
 		})
 

--- a/pkg/controller/noderollout/status/status_test.go
+++ b/pkg/controller/noderollout/status/status_test.go
@@ -176,59 +176,6 @@ var _ = Describe("NodeRollout Status Suite", func() {
 			})
 		})
 
-		Context("when no existing ReplacementsFailed is set", func() {
-			var replacementsFailed []string
-
-			BeforeEach(func() {
-				replacementsFailed = []string{"example-master-1", "example-master-2", "example-worker-1", "example-worker-2"}
-				Expect(nodeRollout.Status.ReplacementsFailed).To(BeEmpty())
-				result.ReplacementsFailed = replacementsFailed
-			})
-
-			PIt("sets the ReplacementsFailed field", func() {
-				m.Eventually(nodeRollout, timeout).Should(utils.WithNodeRolloutStatusField("ReplacementsFailed", Equal(replacementsFailed)))
-			})
-
-			PIt("sets the ReplacementsFailedCount field", func() {
-				m.Eventually(nodeRollout, timeout).Should(utils.WithNodeRolloutStatusField("ReplacementsFailedCount", Equal(len(replacementsFailed))))
-			})
-
-			PIt("does not cause an error", func() {
-				Expect(updateErr).To(BeNil())
-			})
-		})
-
-		Context("when an existing ReplacementsFailed is set", func() {
-			var replacementsFailed []string
-			var existingReplacementsFailed []string
-
-			BeforeEach(func() {
-				// Set up the existing expected state
-				existingReplacementsFailed = []string{"example-master-1", "example-worker-1"}
-				m.Update(nodeRollout, func(obj utils.Object) utils.Object {
-					nr, _ := obj.(*navarchosv1alpha1.NodeRollout)
-					nr.Status.ReplacementsFailed = existingReplacementsFailed
-					nr.Status.ReplacementsFailedCount = len(existingReplacementsFailed)
-					return nr
-				}, timeout).Should(Succeed())
-
-				replacementsFailed = []string{"example-master-2", "example-worker-2"}
-				result.ReplacementsFailed = replacementsFailed
-			})
-
-			PIt("updates the ReplacementsFailed field", func() {
-				m.Eventually(nodeRollout, timeout).Should(utils.WithNodeRolloutStatusField("ReplacementsFailed", Equal(replacementsFailed)))
-			})
-
-			PIt("updates the ReplacementsFailedCount field", func() {
-				m.Eventually(nodeRollout, timeout).Should(utils.WithNodeRolloutStatusField("ReplacementsFailedCount", Equal(len(replacementsFailed))))
-			})
-
-			PIt("does not cause an error", func() {
-				Expect(updateErr).To(BeNil())
-			})
-		})
-
 		Context("when the ReplacementsCompletedError is not set in the Result", func() {
 			PIt("updates the status condition", func() {
 				m.Eventually(nodeRollout, timeout).Should(

--- a/pkg/controller/noderollout/status/types.go
+++ b/pkg/controller/noderollout/status/types.go
@@ -28,8 +28,4 @@ type Result struct {
 	// does not exist on the cluster.
 	// This list will be merged with the existing status list.
 	ReplacementsCompleted []string
-
-	// This should be a list of any currently failing NodeReplacements.
-	// This list will replace the existing status list.
-	ReplacementsFailed []string
 }


### PR DESCRIPTION
@gargath and I discussed how failure in this manner is not particularly Kubernetes native. If a deployment rollout gets stuck for any reason, the cluster operator can fix the issue and the rollout will continue. 

We would like similar behaviour for Navarchos. If a drain is blocked for some reason, the cluster operator can fix this issue and the node replacements should then be able to continue