### PR TITLE
[IS-609] - update controller runtime

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,14 +10,6 @@
   version = "v0.41.0"
 
 [[projects]]
-  digest = "1:464aef731a5f82ded547c62e249a2e9ec59fbbc9ddab53cda7b9857852630a61"
-  name = "github.com/appscode/jsonpatch"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "7c0e3b262f30165a8ec3d0b4c6059fd92703bfb2"
-  version = "1.0.0"
-
-[[projects]]
   digest = "1:7679b7fa4a39470d9ed29a6026bf1ab4a679d82414e24867f4ffc3e5875ecf54"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
@@ -43,6 +35,14 @@
   pruneopts = "T"
   revision = "6ac3b8eb89d325e5c750d77f344a6870464d03c3"
   version = "v2.9.6"
+
+[[projects]]
+  digest = "1:a9b6b136cce3ef6eb805be0d4728810d694b4ab323a54bf2da918c913c05c1cc"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "026c730a0dcc5d11f93f1cf1cc65b01247ea7b6f"
+  version = "v4.5.0"
 
 [[projects]]
   digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
@@ -77,12 +77,12 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:92755a73daaa2397bbd4fd7b14d920decd24c0669b1d58db7e4ef986b1934e5f"
-  name = "github.com/gobuffalo/envy"
+  digest = "1:f6ca5975d71edbb975eb76351e919b5d001bd4061e81a82e8b10299b113c3e98"
+  name = "github.com/gobuffalo/flect"
   packages = ["."]
   pruneopts = "T"
-  revision = "043cb4b8af871b49563291e32c66bb84378a60ac"
-  version = "v1.7.0"
+  revision = "86360480338dcc8c7b61de28a928595f77079989"
+  version = "v0.1.6"
 
 [[projects]]
   digest = "1:c6e109ed32d266dea072dd6d00e3ee26fb960f86ed0ba7f6a07e5d2bfdeab868"
@@ -126,14 +126,6 @@
   version = "v1.3.1"
 
 [[projects]]
-  digest = "1:0bfbe13936953a98ae3cfe8ed6670d396ad81edf069a806d2f6515d7bb6950df"
-  name = "github.com/google/btree"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
-  version = "v1.0.0"
-
-[[projects]]
   digest = "1:a6181aca1fd5e27103f9a920876f29ac72854df7345a39f3b01e61c8c94cc8af"
   name = "github.com/google/gofuzz"
   packages = ["."]
@@ -160,17 +152,6 @@
   pruneopts = "T"
   revision = "e73c7ec21d36ddb0711cb36d1502d18363b5c2c9"
   version = "v0.3.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:3fd71568acc0a8122ddfda5873fb47ce0f40da6788a6d8872f4cc20ff7e8f502"
-  name = "github.com/gregjones/httpcache"
-  packages = [
-    ".",
-    "diskcache",
-  ]
-  pruneopts = "T"
-  revision = "901d90724c7919163f472a9812253fb26761123d"
 
 [[projects]]
   digest = "1:d15ee511aa0f56baacc1eb4c6b922fa1c03b38413b6be18166b996d82a0156ea"
@@ -214,28 +195,12 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:ee5840274624ad20cac08227aeca582fbdaf3727ef9dd37ae935706240679e09"
-  name = "github.com/joho/godotenv"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "23d116af351c84513e1946b527c88823e476be13"
-  version = "v1.3.0"
-
-[[projects]]
   digest = "1:e4f630893d2bbf8c268eba14e7cc92ef8844ee259a45e21ea77cf7656544cb7e"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "T"
   revision = "0ff49de124c6f76f8494e194af75bde0f1a49a29"
   version = "v1.1.6"
-
-[[projects]]
-  digest = "1:3804a3a02964db8e6db3e5e7960ac1c1a9b12835642dd4f4ac4e56c749ec73eb"
-  name = "github.com/markbates/inflect"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "24b83195037b3bc61fcda2d28b7b0518bce293b6"
-  version = "v1.0.4"
 
 [[projects]]
   digest = "1:a8e3d14801bed585908d130ebfc3b925ba642208e6f30d879437ddfc7bb9b413"
@@ -320,22 +285,6 @@
   version = "v1.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:e3c9ed9dca0ac77a50165f6752391fd915b26a020691a731d778304e7b17725b"
-  name = "github.com/petar/GoLLRB"
-  packages = ["llrb"]
-  pruneopts = "T"
-  revision = "33fb24c13b99c46c93183c291836c573ac382536"
-
-[[projects]]
-  digest = "1:d7a1d3a7087a69064f1055538e59873c01dac493e5ff30893b1bcaeb822686c4"
-  name = "github.com/peterbourgon/diskv"
-  packages = ["."]
-  pruneopts = "T"
-  revision = "0be1b92a6df0e4f5cb0a5d15fb7f643d0ad93ce6"
-  version = "v3.0.0"
-
-[[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -385,18 +334,6 @@
   pruneopts = "T"
   revision = "3f98efb27840a48a7a2898ec80be07674d19f9c8"
   version = "v0.0.3"
-
-[[projects]]
-  digest = "1:5e2ebcff4614ac5a6d9abbbaaa6df76082658d797621f2a25e54c5e5e4203161"
-  name = "github.com/rogpeppe/go-internal"
-  packages = [
-    "modfile",
-    "module",
-    "semver",
-  ]
-  pruneopts = "T"
-  revision = "438578804ca6f31be148c27683afc419ce47c06e"
-  version = "v1.3.0"
 
 [[projects]]
   digest = "1:dee0cc3252ce6fcc3334c9529abd32925f2aaf072c90336a5a38254953564aa5"
@@ -574,6 +511,14 @@
   revision = "72ffa07ba3db8d09f5215feec0f89464f3028f8e"
 
 [[projects]]
+  digest = "1:7c65747ea6380bd254afcf806cc06be1d1a9de73ee7ce6e896127f54e1ee10fe"
+  name = "gomodules.xyz/jsonpatch"
+  packages = ["v2"]
+  pruneopts = "T"
+  revision = "e8422f09d27ee2c8cfb2c7f8089eb9eeb0764849"
+  version = "v2.0.1"
+
+[[projects]]
   digest = "1:04b9a99f5ff102323281698000a18c2daabde66baea55fe74941d6c82ed715a8"
   name = "google.golang.org/appengine"
   packages = [
@@ -626,11 +571,10 @@
   version = "v2.2.2"
 
 [[projects]]
-  digest = "1:a361d526b77e9f68ba9f5d6f2f24e58e00d87f837b1d4cfc977047a37a7522cf"
+  digest = "1:bbd4fd8b2a8a552b0c8ac509c3993c83c22897804bb262ae176e6bd202ab9f6b"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
-    "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
     "apps/v1beta1",
@@ -647,15 +591,20 @@
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
+    "coordination/v1",
     "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
     "networking/v1",
+    "networking/v1beta1",
+    "node/v1alpha1",
+    "node/v1beta1",
     "policy/v1beta1",
     "rbac/v1",
     "rbac/v1alpha1",
     "rbac/v1beta1",
+    "scheduling/v1",
     "scheduling/v1alpha1",
     "scheduling/v1beta1",
     "settings/v1alpha1",
@@ -664,11 +613,11 @@
     "storage/v1beta1",
   ]
   pruneopts = "T"
-  revision = "5cb15d34447165a97c76ed5a60e4e99c8a01ecfe"
-  version = "kubernetes-1.13.4"
+  revision = "539a33f6e81741ed7bc3f69e07b4a966788723cf"
+  version = "kubernetes-1.14.4"
 
 [[projects]]
-  digest = "1:29ba6118af0c631600c5f773d4c99b09ffb6306ceefcffa91bb524483da7a67b"
+  digest = "1:bbfaf1b9636fe8a4a58f6e005137b209ab246199ecd434a78e330c00e32b87a8"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -678,11 +627,11 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "T"
-  revision = "d002e88f6236312f0289d9d1deab106751718ff0"
-  version = "kubernetes-1.13.4"
+  revision = "527eacf2d4b757e37a6ac23d2b866e5607441998"
+  version = "kubernetes-1.14.4"
 
 [[projects]]
-  digest = "1:82717527f44f2cb9a2a784a427a7ab9bd7f883848bdfabcf70bef8e300b69fa5"
+  digest = "1:e0ec21060953ced38018fae667796890cd67dac80f969eec1634ff5ecfcf59a8"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -730,18 +679,17 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "T"
-  revision = "86fb29eff6288413d76bd8506874fddd9fccdff0"
-  version = "kubernetes-1.13.4"
+  revision = "6a84e37a896db9780c75367af8d2ed2bb944022e"
+  version = "kubernetes-1.14.4"
 
 [[projects]]
-  digest = "1:00cdd77acb3883ae851a1cd8c2b3ede01cd974dd9283ff4022f98dbb6e1455dd"
+  digest = "1:cc1ba75c11e8127212c347bf215e0bac83bd999a1429281e2325ce053b798aa4"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
     "dynamic",
     "kubernetes",
     "kubernetes/scheme",
-    "kubernetes/typed/admissionregistration/v1alpha1",
     "kubernetes/typed/admissionregistration/v1beta1",
     "kubernetes/typed/apps/v1",
     "kubernetes/typed/apps/v1beta1",
@@ -758,15 +706,20 @@
     "kubernetes/typed/batch/v1beta1",
     "kubernetes/typed/batch/v2alpha1",
     "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/coordination/v1",
     "kubernetes/typed/coordination/v1beta1",
     "kubernetes/typed/core/v1",
     "kubernetes/typed/events/v1beta1",
     "kubernetes/typed/extensions/v1beta1",
     "kubernetes/typed/networking/v1",
+    "kubernetes/typed/networking/v1beta1",
+    "kubernetes/typed/node/v1alpha1",
+    "kubernetes/typed/node/v1beta1",
     "kubernetes/typed/policy/v1beta1",
     "kubernetes/typed/rbac/v1",
     "kubernetes/typed/rbac/v1alpha1",
     "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1",
     "kubernetes/typed/scheduling/v1alpha1",
     "kubernetes/typed/scheduling/v1beta1",
     "kubernetes/typed/settings/v1alpha1",
@@ -794,25 +747,24 @@
     "tools/metrics",
     "tools/pager",
     "tools/record",
+    "tools/record/util",
     "tools/reference",
     "transport",
-    "util/buffer",
     "util/cert",
     "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
-    "util/integer",
     "util/jsonpath",
+    "util/keyutil",
     "util/retry",
     "util/workqueue",
   ]
   pruneopts = "T"
-  revision = "b40b2a5939e43f7ffe0028ad67586b7ce50bb675"
-  version = "kubernetes-1.13.4"
+  revision = "62e1c231c5dca3a31a42634c83cc17910a3b6a48"
+  version = "kubernetes-1.14.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:354f455611e3f1cef4ba2a1c5eb153c0f00ab559d51c531528c7521efec7c04b"
+  digest = "1:2d821667dbd520a7ef31bdc923543f197ba30021b4317fd8871618ada52f23b0"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -829,11 +781,11 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "583809a49343b2690e46e4cba3496f8e12c27922"
+  revision = "50b561225d70b3eb79a1faafd3dfe7b1a62cbe73"
+  version = "kubernetes-1.14.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:06449c9193d3d1f9375b97d1ce8a3f7a59d531c69ca34a6b0663cf3c144c2178"
+  digest = "1:2b9071c93303f1196cfe959c7f7f69ed1e4a5180f240a259536c5886f79f86d4"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -845,7 +797,7 @@
     "types",
   ]
   pruneopts = "T"
-  revision = "e17681d19d3ac4837a019ece36c2a0ec31ffe985"
+  revision = "0689ccc1d7d65d9dd1bedcc3b0b1ed7df91ba266"
 
 [[projects]]
   digest = "1:d14069dfa56161d0463bf00366d9b28e37f9fe9a4d4242b96119023ead196bca"
@@ -864,7 +816,19 @@
   revision = "db7b694dc208eead64d38030265f702db593fcf2"
 
 [[projects]]
-  digest = "1:fbd9138a454764d4037f8edeb7bdea3f4ef4ad24b672a52cceff2a9609aacf91"
+  branch = "master"
+  digest = "1:75ea823fa8126ea20f2c34040f3f34876a1e52427f5831045da3605d97610b7e"
+  name = "k8s.io/utils"
+  packages = [
+    "buffer",
+    "integer",
+    "trace",
+  ]
+  pruneopts = "T"
+  revision = "6c36bc71fc4aeb1f49801054e71aebdaef1fbeb4"
+
+[[projects]]
+  digest = "1:e31911fc785e76bdbfab6a4fff412660edc894856ff1416c6bbfee7258fa78f0"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -873,19 +837,21 @@
     "pkg/client/apiutil",
     "pkg/client/config",
     "pkg/controller",
-    "pkg/controller/controllerutil",
     "pkg/envtest",
     "pkg/envtest/printer",
     "pkg/event",
     "pkg/handler",
     "pkg/internal/controller",
     "pkg/internal/controller/metrics",
+    "pkg/internal/log",
     "pkg/internal/objectutil",
     "pkg/internal/recorder",
     "pkg/leaderelection",
+    "pkg/log",
+    "pkg/log/zap",
     "pkg/manager",
+    "pkg/manager/signals",
     "pkg/metrics",
-    "pkg/patch",
     "pkg/predicate",
     "pkg/reconcile",
     "pkg/recorder",
@@ -893,19 +859,20 @@
     "pkg/runtime/log",
     "pkg/runtime/scheme",
     "pkg/runtime/signals",
+    "pkg/scheme",
     "pkg/source",
     "pkg/source/internal",
+    "pkg/webhook",
     "pkg/webhook/admission",
-    "pkg/webhook/admission/types",
+    "pkg/webhook/internal/certwatcher",
     "pkg/webhook/internal/metrics",
-    "pkg/webhook/types",
   ]
   pruneopts = "T"
-  revision = "f1eaba5087d69cebb154c6a48193e6667f5b512c"
-  version = "v0.1.12"
+  revision = "e1159d6655b260c4812fd0792cd1344ecc96a57e"
+  version = "v0.2.0"
 
 [[projects]]
-  digest = "1:403a05a256885221051ab3d11ec3b026ac8eb25927fd479f6f5e70de7cc3a142"
+  digest = "1:46aa448122b04f923ce877ab57d4649dfe5437a028ae8700876d7c5070909b08"
   name = "sigs.k8s.io/controller-tools"
   packages = [
     "cmd/controller-gen",
@@ -919,8 +886,8 @@
     "pkg/webhook",
   ]
   pruneopts = "T"
-  revision = "464fbed97efaced33902e262f09c5eae7315c3e3"
-  version = "v0.1.11"
+  revision = "eb20812245b721a69012140fcf07e887b4f2e5d8"
+  version = "v0.1.12"
 
 [[projects]]
   digest = "1:290b4da306982122bcdff12dbababbb95c6e4a94a2995db88baf235ef2f6e93e"
@@ -952,15 +919,19 @@
     "github.com/onsi/ginkgo/config",
     "github.com/onsi/ginkgo/reporters",
     "github.com/onsi/gomega",
+    "github.com/onsi/gomega/types",
     "golang.org/x/net/context",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/api/policy/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
@@ -969,7 +940,6 @@
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
     "sigs.k8s.io/controller-runtime/pkg/controller",
-    "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
     "sigs.k8s.io/controller-runtime/pkg/envtest",
     "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,13 +22,57 @@ required = [
 
 # STANZAS BELOW ARE GENERATED AND MAY BE WRITTEN - DO NOT MODIFY BELOW THIS LINE.
 
-[[constraint]]
-  name="sigs.k8s.io/controller-runtime"
-  version="v0.1.1"
+[[override]]
+name="k8s.io/kubernetes"
+version="=1.14.4"
 
-[[constraint]]
-  name="sigs.k8s.io/controller-tools"
-  version="v0.1.1"
+[[override]]
+name="k8s.io/api"
+version="kubernetes-1.14.4"
+
+[[override]]
+name="k8s.io/apiextensions-apiserver"
+version="kubernetes-1.14.4"
+
+[[override]]
+name="k8s.io/apimachinery"
+version="kubernetes-1.14.4"
+
+[[override]]
+name="k8s.io/client-go"
+version="kubernetes-1.14.4"
+
+[[override]]
+name="k8s.io/cli-runtime"
+version="kubernetes-1.14.4"
+
+[[override]]
+name="k8s.io/kube-aggregator"
+version="kubernetes-1.14.4"
+
+[[override]]
+name="k8s.io/code-generator"
+version="kubernetes-1.14.4"
+
+[[override]]
+name="k8s.io/gengo"
+revision="0689ccc1d7d65d9dd1bedcc3b0b1ed7df91ba266"
+
+[[override]]
+name="sigs.k8s.io/controller-runtime"
+version="v0.2.0-beta.4"
+
+[[override]]
+name="sigs.k8s.io/controller-tools"
+version="v0.1.12"
+
+[[override]]
+name="sigs.k8s.io/testing_frameworks"
+version="v0.1.1"
+
+[[override]]
+name="sigs.k8s.io/kustomize"
+version="v2.0.3"
 
 # For dependency below: Refer to issue https://github.com/golang/dep/issues/1799
 [[override]]

--- a/pkg/controller/nodereplacement/handler/handler_test.go
+++ b/pkg/controller/nodereplacement/handler/handler_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Handler suite", func() {
 		mgrStopped.Wait()
 
 		pods := &corev1.PodList{}
-		m.List(pods, &client.ListOptions{}).Should(Succeed())
+		m.List(pods).Should(Succeed())
 		for _, pod := range pods.Items {
 			m.UpdateStatus(&pod, setPodSucceeded, timeout).Should(Succeed())
 		}

--- a/pkg/controller/noderollout/handler/handler_test.go
+++ b/pkg/controller/noderollout/handler/handler_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pusher/navarchos/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -55,7 +54,7 @@ var _ = Describe("Handler suite", func() {
 	// name, an owner reference pointing to the given node, and the given priority
 	var checkForNodeReplacement = func(name string, owner *corev1.Node, priority int) {
 		nrList := &navarchosv1alpha1.NodeReplacementList{}
-		m.List(nrList, &client.ListOptions{}, timeout).Should(Succeed())
+		m.List(nrList, timeout).Should(Succeed())
 
 		Expect(nrList.Items).To(ContainElement(SatisfyAll(
 			utils.WithNodeReplacementSpecField("ReplacementSpec", utils.WithReplacementSpecField("Priority", Equal(priority))),
@@ -329,7 +328,7 @@ var _ = Describe("Handler suite", func() {
 
 			PIt("should create new NodeReplacements for the nodes", func() {
 				nrList := &navarchosv1alpha1.NodeReplacementList{}
-				m.List(nrList, &client.ListOptions{}, timeout).Should(Succeed())
+				m.List(nrList, timeout).Should(Succeed())
 
 				items := []*navarchosv1alpha1.NodeReplacement{}
 				for _, nr := range nrList.Items {

--- a/test/utils/delete.go
+++ b/test/utils/delete.go
@@ -18,11 +18,14 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	g "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,18 +36,55 @@ func DeleteAll(cfg *rest.Config, timeout time.Duration, objLists ...runtime.Obje
 	g.Expect(err).ToNot(g.HaveOccurred())
 	for _, objList := range objLists {
 		g.Eventually(func() error {
-			return c.List(context.TODO(), &client.ListOptions{}, objList)
+			return c.List(context.TODO(), objList)
 		}, timeout).Should(g.Succeed())
 		objs, err := apimeta.ExtractList(objList)
 		g.Expect(err).ToNot(g.HaveOccurred())
 		errs := make(chan error, len(objs))
 		for _, obj := range objs {
 			go func(o runtime.Object) {
-				errs <- c.Delete(context.TODO(), o)
+				errs <- deleteObj(c, timeout, o)
 			}(obj)
 		}
 		for range objs {
 			g.Expect(<-errs).ToNot(g.HaveOccurred())
 		}
 	}
+}
+
+func deleteObj(c client.Client, timeout time.Duration, obj runtime.Object) error {
+	metaAccessor, err := apimeta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	err = c.Delete(context.TODO(), obj)
+	if err != nil {
+		return err
+	}
+
+	checkDeleted := func() error {
+		key := types.NamespacedName{Namespace: metaAccessor.GetNamespace(), Name: metaAccessor.GetName()}
+
+		err := c.Get(context.TODO(), key, obj)
+		if err != nil && errors.IsNotFound(err) {
+			// Object has been deleted
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		if metaAccessor.GetDeletionTimestamp() == nil {
+			return fmt.Errorf("Object has not been deleted")
+		}
+		if len(metaAccessor.GetFinalizers()) > 0 {
+			return fmt.Errorf("Object has remaining Finalizers: %v", metaAccessor.GetFinalizers())
+		}
+		// If the object has deletion timestamp and no finalizers,
+		// it shouldn't exist and we shouldn't get here
+		panic(fmt.Sprintf("Unexpected Object state: %+v", obj))
+	}
+
+	g.Eventually(checkDeleted, timeout).Should(g.Succeed())
+	return nil
 }

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -108,9 +108,9 @@ func (m *Matcher) Get(obj Object, intervals ...interface{}) gomega.GomegaAsyncAs
 }
 
 // List gets the list object from the API server
-func (m *Matcher) List(obj runtime.Object, opts *client.ListOptions, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+func (m *Matcher) List(obj runtime.Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
 	list := func() error {
-		return m.Client.List(context.TODO(), opts, obj)
+		return m.Client.List(context.TODO(), obj)
 	}
 	return gomega.Eventually(list, intervals...)
 }
@@ -168,7 +168,7 @@ func (m *Matcher) eventuallyObject(obj Object, intervals ...interface{}) gomega.
 // eventuallyList gets a list type  from the API server
 func (m *Matcher) eventuallyList(obj runtime.Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
 	list := func() runtime.Object {
-		err := m.Client.List(context.TODO(), &client.ListOptions{}, obj)
+		err := m.Client.List(context.TODO(), obj)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
We are behind and should keep dependencies up to date so that the dependencies are as close to the running K8s versions as possible.

This should upgrade the dependencies to 1.14 

