### PR TITLE
[IS-634] - Implement Handler for New NodeRollouts

### DIFF
--- a/pkg/controller/noderollout/handler/handler.go
+++ b/pkg/controller/noderollout/handler/handler.go
@@ -35,6 +35,8 @@ type NodeRolloutHandler struct {
 	maxAge time.Duration
 }
 
+// nodeReplacementSpec is a container to allow easier construction of
+// NodeReplacements
 type nodeReplacementSpec struct {
 	node            corev1.Node
 	replacementSpec navarchosv1alpha1.NodeReplacementSpec
@@ -102,8 +104,8 @@ func (h *NodeRolloutHandler) handleNew(instance *navarchosv1alpha1.NodeRollout) 
 	return result
 }
 
-// filterNodeSelectors filters the list of all nodes. If a nodes labels match it
-// adds the node to the nodeMap
+// filterNodeSelectors filters the list of all nodes.  If a nodes labels match
+// it adds the node to the nodeMap
 func filterNodeSelectors(nodes *corev1.NodeList, selectors []navarchosv1alpha1.NodeLabelSelector, nodeMap map[string]nodeReplacementSpec) (map[string]nodeReplacementSpec, error) {
 	for _, node := range nodes.Items {
 		labels := metalabels.Set(node.GetLabels())
@@ -148,14 +150,8 @@ func filterNodeNames(nodes *corev1.NodeList, nodeNames []navarchosv1alpha1.NodeN
 	return nodeMap
 }
 
-func createNodeReplacementFromSpec(spec navarchosv1alpha1.NodeReplacementSpec, rolloutOwner *navarchosv1alpha1.NodeRollout, nodeOwner *corev1.Node) navarchosv1alpha1.NodeReplacement {
-	// gvk := schema.GroupVersionKind{
-	// 	Group:   "navarchos.pusher.com",
-	// 	Version: "v1alpha1",
-	// 	Kind:    "NodeReplacement",
-	// }
-
-	nodeReplacement := navarchosv1alpha1.NodeReplacement{
+// createNodeReplacementFromSpec takes a NodeReplacementSpec, NodeRollout and
+// node and returns a NodeReplacement with the correct owners
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: navarchosv1alpha1.SchemeGroupVersion.String(),
 			Kind:       "NodeReplacement",

--- a/pkg/controller/noderollout/handler/handler.go
+++ b/pkg/controller/noderollout/handler/handler.go
@@ -1,10 +1,16 @@
 package handler
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
 	"github.com/pusher/navarchos/pkg/controller/noderollout/status"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metalabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -29,6 +35,11 @@ type NodeRolloutHandler struct {
 	maxAge time.Duration
 }
 
+type nodeReplacementSpec struct {
+	node            corev1.Node
+	replacementSpec navarchosv1alpha1.NodeReplacementSpec
+}
+
 // NewNodeRolloutHandler creates a new NodeRolloutHandler
 func NewNodeRolloutHandler(c client.Client, opts *Options) *NodeRolloutHandler {
 	opts.Complete()
@@ -49,13 +60,129 @@ func (h *NodeRolloutHandler) Handle(instance *navarchosv1alpha1.NodeRollout) *st
 	case navarchosv1alpha1.RolloutPhaseCompleted:
 		return h.handleCompleted(instance)
 	default:
-		return &status.Result{}
+		return h.handleNew(instance)
 	}
 
 }
 
+// handleNew handles a NodeRollout in the 'New' phase
 func (h *NodeRolloutHandler) handleNew(instance *navarchosv1alpha1.NodeRollout) *status.Result {
-	return &status.Result{}
+	result := &status.Result{}
+	nodes := &corev1.NodeList{}
+	err := h.client.List(context.Background(), nodes)
+	if err != nil {
+		result.ReplacementsCompletedError = err
+		return result
+	}
+
+	var nodeReplacementMap map[string]nodeReplacementSpec
+	nodeReplacementMap = make(map[string]nodeReplacementSpec)
+
+	nodeReplacementMap, err = filterNodeSelectors(nodes, instance.Spec.NodeSelectors, nodeReplacementMap)
+	if err != nil {
+		result.ReplacementsCompletedError = err
+		return result
+	}
+
+	nodeReplacementMap = filterNodeNames(nodes, instance.Spec.NodeNames, nodeReplacementMap)
+
+	// create the NodeReplacements
+	for _, spec := range nodeReplacementMap {
+		nodeReplacement := createNodeReplacementFromSpec(spec.replacementSpec, instance, &spec.node)
+		err := h.client.Create(context.Background(), &nodeReplacement)
+		if err != nil {
+			result.ReplacementsCompletedError = err
+			return result
+		}
+		result.ReplacementsCreated = append(result.ReplacementsCreated, spec.replacementSpec.NodeName)
+	}
+	newPhase := navarchosv1alpha1.RolloutPhaseInProgress
+	result.Phase = &newPhase
+
+	return result
+}
+
+// filterNodeSelectors filters the list of all nodes. If a nodes labels match it
+// adds the node to the nodeMap
+func filterNodeSelectors(nodes *corev1.NodeList, selectors []navarchosv1alpha1.NodeLabelSelector, nodeMap map[string]nodeReplacementSpec) (map[string]nodeReplacementSpec, error) {
+	for _, node := range nodes.Items {
+		labels := metalabels.Set(node.GetLabels())
+		for _, nls := range selectors {
+			selector, err := metav1.LabelSelectorAsSelector(&nls.LabelSelector)
+			if err != nil {
+				return nil, err
+			}
+			if selector.Matches(labels) {
+				nodeMap[node.GetName()] = nodeReplacementSpec{
+					node: node,
+					replacementSpec: navarchosv1alpha1.NodeReplacementSpec{
+						ReplacementSpec: nls.ReplacementSpec,
+						NodeName:        node.GetName(),
+						NodeUID:         node.GetUID(),
+					},
+				}
+			}
+
+		}
+	}
+	return nodeMap, nil
+}
+
+// filterNodeNames filters the list of all nodes. If a nodes name matches one
+// provided it adds the node to the nodeMap
+func filterNodeNames(nodes *corev1.NodeList, nodeNames []navarchosv1alpha1.NodeName, nodeMap map[string]nodeReplacementSpec) map[string]nodeReplacementSpec {
+	for _, node := range nodes.Items {
+		for _, selectedName := range nodeNames {
+			if node.GetName() == selectedName.Name {
+				nodeMap[node.GetName()] = nodeReplacementSpec{
+					node: node,
+					replacementSpec: navarchosv1alpha1.NodeReplacementSpec{
+						ReplacementSpec: selectedName.ReplacementSpec,
+						NodeName:        node.GetName(),
+						NodeUID:         node.GetUID(),
+					},
+				}
+			}
+		}
+	}
+	return nodeMap
+}
+
+func createNodeReplacementFromSpec(spec navarchosv1alpha1.NodeReplacementSpec, rolloutOwner *navarchosv1alpha1.NodeRollout, nodeOwner *corev1.Node) navarchosv1alpha1.NodeReplacement {
+	// gvk := schema.GroupVersionKind{
+	// 	Group:   "navarchos.pusher.com",
+	// 	Version: "v1alpha1",
+	// 	Kind:    "NodeReplacement",
+	// }
+
+	nodeReplacement := navarchosv1alpha1.NodeReplacement{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: navarchosv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "NodeReplacement",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", spec.NodeName),
+			OwnerReferences: []metav1.OwnerReference{
+				newOwnerRef(rolloutOwner, rolloutOwner.GroupVersionKind(), true, true),
+				newOwnerRef(nodeOwner, nodeOwner.GroupVersionKind(), false, false),
+			},
+		},
+		Spec:   spec,
+		Status: navarchosv1alpha1.NodeReplacementStatus{},
+	}
+	return nodeReplacement
+}
+
+// newOwnerRef creates an OwnerReference pointing to the given owner.
+func newOwnerRef(owner metav1.Object, gvk schema.GroupVersionKind, isController bool, blockOwnerDeletion bool) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion:         gvk.GroupVersion().String(),
+		Kind:               gvk.Kind,
+		Name:               owner.GetName(),
+		UID:                owner.GetUID(),
+		BlockOwnerDeletion: &blockOwnerDeletion,
+		Controller:         &isController,
+	}
 }
 func (h *NodeRolloutHandler) handleInProgress(instance *navarchosv1alpha1.NodeRollout) *status.Result {
 	return &status.Result{}

--- a/pkg/controller/noderollout/handler/handler.go
+++ b/pkg/controller/noderollout/handler/handler.go
@@ -41,5 +41,25 @@ func NewNodeRolloutHandler(c client.Client, opts *Options) *NodeRolloutHandler {
 // Handle performs the business logic of the NodeRollout and returns information
 // in a Result
 func (h *NodeRolloutHandler) Handle(instance *navarchosv1alpha1.NodeRollout) *status.Result {
+	switch instance.Status.Phase {
+	case navarchosv1alpha1.RolloutPhaseNew:
+		return h.handleNew(instance)
+	case navarchosv1alpha1.RolloutPhaseInProgress:
+		return h.handleInProgress(instance)
+	case navarchosv1alpha1.RolloutPhaseCompleted:
+		return h.handleCompleted(instance)
+	default:
+		return &status.Result{}
+	}
+
+}
+
+func (h *NodeRolloutHandler) handleNew(instance *navarchosv1alpha1.NodeRollout) *status.Result {
+	return &status.Result{}
+}
+func (h *NodeRolloutHandler) handleInProgress(instance *navarchosv1alpha1.NodeRollout) *status.Result {
+	return &status.Result{}
+}
+func (h *NodeRolloutHandler) handleCompleted(instance *navarchosv1alpha1.NodeRollout) *status.Result {
 	return &status.Result{}
 }

--- a/pkg/controller/noderollout/handler/handler.go
+++ b/pkg/controller/noderollout/handler/handler.go
@@ -64,7 +64,6 @@ func (h *NodeRolloutHandler) Handle(instance *navarchosv1alpha1.NodeRollout) *st
 	default:
 		return h.handleNew(instance)
 	}
-
 }
 
 // handleNew handles a NodeRollout in the 'New' phase
@@ -77,8 +76,7 @@ func (h *NodeRolloutHandler) handleNew(instance *navarchosv1alpha1.NodeRollout) 
 		return result
 	}
 
-	var nodeReplacementMap map[string]nodeReplacementSpec
-	nodeReplacementMap = make(map[string]nodeReplacementSpec)
+	nodeReplacementMap := make(map[string]nodeReplacementSpec)
 
 	nodeReplacementMap, err = filterNodeSelectors(nodes, instance.Spec.NodeSelectors, nodeReplacementMap)
 	if err != nil {
@@ -91,15 +89,15 @@ func (h *NodeRolloutHandler) handleNew(instance *navarchosv1alpha1.NodeRollout) 
 	// create the NodeReplacements
 	for _, spec := range nodeReplacementMap {
 		nodeReplacement := createNodeReplacementFromSpec(spec.replacementSpec, instance, &spec.node)
-		err := h.client.Create(context.Background(), &nodeReplacement)
+		err := h.client.Create(context.Background(), nodeReplacement)
 		if err != nil {
 			result.ReplacementsCompletedError = err
 			return result
 		}
 		result.ReplacementsCreated = append(result.ReplacementsCreated, spec.replacementSpec.NodeName)
 	}
-	newPhase := navarchosv1alpha1.RolloutPhaseInProgress
-	result.Phase = &newPhase
+	inProgress := navarchosv1alpha1.RolloutPhaseInProgress
+	result.Phase = &inProgress
 
 	return result
 }
@@ -107,11 +105,11 @@ func (h *NodeRolloutHandler) handleNew(instance *navarchosv1alpha1.NodeRollout) 
 // filterNodeSelectors filters the list of all nodes.  If a nodes labels match
 // it adds the node to the nodeMap
 func filterNodeSelectors(nodes *corev1.NodeList, selectors []navarchosv1alpha1.NodeLabelSelector, nodeMap map[string]nodeReplacementSpec) (map[string]nodeReplacementSpec, error) {
-		for _, nls := range selectors {
-			selector, err := metav1.LabelSelectorAsSelector(&nls.LabelSelector)
-			if err != nil {
-				return nil, err
-			}
+	for _, nls := range selectors {
+		selector, err := metav1.LabelSelectorAsSelector(&nls.LabelSelector)
+		if err != nil {
+			return nil, err
+		}
 		// check which nodes match the LabelSelector
 		for _, node := range nodes.Items {
 			labels := metalabels.Set(node.GetLabels())
@@ -128,20 +126,20 @@ func filterNodeSelectors(nodes *corev1.NodeList, selectors []navarchosv1alpha1.N
 // nodeReplacementSpec
 func newNodeReplacementSpec(node corev1.Node, replacementSpec navarchosv1alpha1.ReplacementSpec) nodeReplacementSpec {
 	return nodeReplacementSpec{
-					node: node,
-					replacementSpec: navarchosv1alpha1.NodeReplacementSpec{
+		node: node,
+		replacementSpec: navarchosv1alpha1.NodeReplacementSpec{
 			ReplacementSpec: replacementSpec,
-						NodeName:        node.GetName(),
-						NodeUID:         node.GetUID(),
-					},
-				}
-			}
+			NodeName:        node.GetName(),
+			NodeUID:         node.GetUID(),
+		},
+	}
+}
 
 // filterNodeNames filters the list of all nodes. If a nodes name matches one
 // provided it adds the node to the nodeMap
 func filterNodeNames(nodes *corev1.NodeList, nodeNames []navarchosv1alpha1.NodeName, nodeMap map[string]nodeReplacementSpec) map[string]nodeReplacementSpec {
 	for _, selectedName := range nodeNames {
-	for _, node := range nodes.Items {
+		for _, node := range nodes.Items {
 			if node.GetName() == selectedName.Name {
 				nodeMap[node.GetName()] = newNodeReplacementSpec(node, selectedName.ReplacementSpec)
 				break
@@ -169,7 +167,6 @@ func createNodeReplacementFromSpec(spec navarchosv1alpha1.NodeReplacementSpec, r
 		Spec:   spec,
 		Status: navarchosv1alpha1.NodeReplacementStatus{},
 	}
-	return nodeReplacement
 }
 
 // newOwnerRef creates an OwnerReference pointing to the given owner.

--- a/pkg/controller/noderollout/handler/handler_test.go
+++ b/pkg/controller/noderollout/handler/handler_test.go
@@ -182,8 +182,8 @@ var _ = Describe("Handler suite", func() {
 			})
 
 			It("does not set any error", func() {
-				Expect(result.ReplacementsCompletedError).To(BeNil())
-				Expect(result.ReplacementsCompletedReason).To(BeEmpty())
+				Expect(result.ReplacementsCreatedError).To(BeNil())
+				Expect(result.ReplacementsCreatedReason).To(BeEmpty())
 			})
 		})
 
@@ -250,8 +250,8 @@ var _ = Describe("Handler suite", func() {
 			})
 
 			It("does not set any error", func() {
-				Expect(result.ReplacementsCompletedError).To(BeNil())
-				Expect(result.ReplacementsCompletedReason).To(BeEmpty())
+				Expect(result.ReplacementsCreatedError).To(BeNil())
+				Expect(result.ReplacementsCreatedReason).To(BeEmpty())
 			})
 		})
 
@@ -305,8 +305,8 @@ var _ = Describe("Handler suite", func() {
 			})
 
 			It("does not set any error", func() {
-				Expect(result.ReplacementsCompletedError).To(BeNil())
-				Expect(result.ReplacementsCompletedReason).To(BeEmpty())
+				Expect(result.ReplacementsCreatedError).To(BeNil())
+				Expect(result.ReplacementsCreatedReason).To(BeEmpty())
 			})
 		})
 

--- a/pkg/controller/noderollout/handler/handler_test.go
+++ b/pkg/controller/noderollout/handler/handler_test.go
@@ -57,10 +57,10 @@ var _ = Describe("Handler suite", func() {
 		m.List(nrList, timeout).Should(Succeed())
 
 		Expect(nrList.Items).To(ContainElement(SatisfyAll(
-			utils.WithNodeReplacementSpecField("ReplacementSpec", utils.WithReplacementSpecField("Priority", Equal(priority))),
-			utils.WithNodeReplacementSpecField("NodeName", Equal(owner.GetName())),
-			utils.WithNodeReplacementSpecField("NodeUID", Equal(owner.GetUID())),
-			utils.WithObjectMetaField("OwnerReferences", SatisfyAll(
+			utils.WithField("Spec.ReplacementSpec.Priority", Equal(&priority)),
+			utils.WithField("Spec.NodeName", Equal(owner.GetName())),
+			utils.WithField("Spec.NodeUID", Equal(owner.GetUID())),
+			utils.WithField("ObjectMeta.OwnerReferences", SatisfyAll(
 				ContainElement(Equal(utils.GetOwnerReferenceForNode(owner))),
 				ContainElement(Equal(utils.GetOwnerReferenceForNodeRollout(nodeRollout))),
 			)),
@@ -91,6 +91,7 @@ var _ = Describe("Handler suite", func() {
 
 		nodeRollout = utils.ExampleNodeRollout.DeepCopy()
 		m.Create(nodeRollout).Should(Succeed())
+		m.Get(nodeRollout, timeout).Should(Succeed())
 
 		// Create some nodes to act as owners for the NodeReplacements created
 		masterNode1 = utils.ExampleNodeMaster1.DeepCopy()
@@ -137,19 +138,19 @@ var _ = Describe("Handler suite", func() {
 				Expect(nodeRollout).To(utils.WithNodeRolloutSpecField("NodeNames", BeEmpty()))
 			})
 
-			PIt("creates a NodeReplacement for example-master-1", func() {
+			It("creates a NodeReplacement for example-master-1", func() {
 				checkForNodeReplacement("example-master-1", masterNode1, 15)
 			})
 
-			PIt("creates a NodeReplacement for example-master-2", func() {
+			It("creates a NodeReplacement for example-master-2", func() {
 				checkForNodeReplacement("example-master-2", masterNode2, 15)
 			})
 
-			PIt("creates a NodeReplacement for example-worker-1", func() {
+			It("creates a NodeReplacement for example-worker-1", func() {
 				checkForNodeReplacement("example-worker-1", workerNode1, 5)
 			})
 
-			PIt("creates a NodeReplacement for example-worker-2", func() {
+			It("creates a NodeReplacement for example-worker-2", func() {
 				checkForNodeReplacement("example-worker-2", workerNode2, 5)
 			})
 
@@ -162,7 +163,7 @@ var _ = Describe("Handler suite", func() {
 				m.Get(nr, consistentlyTimeout).ShouldNot(Succeed())
 			})
 
-			PIt("populates the Result ReplacementsCreated field", func() {
+			It("populates the Result ReplacementsCreated field", func() {
 				Expect(result.ReplacementsCreated).To(ConsistOf(
 					"example-master-1",
 					"example-master-2",
@@ -171,8 +172,9 @@ var _ = Describe("Handler suite", func() {
 				))
 			})
 
-			PIt("sets the Result Phase to InProgress", func() {
-				Expect(result.Phase).To(Equal(navarchosv1alpha1.RolloutPhaseInProgress))
+			It("sets the Result Phase to InProgress", func() {
+				inProgress := navarchosv1alpha1.RolloutPhaseInProgress
+				Expect(result.Phase).To(Equal(&inProgress))
 			})
 
 			It("does not set the Result ReplacementsCompleted field", func() {
@@ -196,7 +198,7 @@ var _ = Describe("Handler suite", func() {
 				Expect(nodeRollout).To(utils.WithNodeRolloutSpecField("NodeSelectors", BeEmpty()))
 			})
 
-			PIt("creates a NodeReplacement for example-master-1", func() {
+			It("creates a NodeReplacement for example-master-1", func() {
 				checkForNodeReplacement("example-master-1", masterNode1, 20)
 			})
 
@@ -209,7 +211,7 @@ var _ = Describe("Handler suite", func() {
 				m.Get(nr, consistentlyTimeout).ShouldNot(Succeed())
 			})
 
-			PIt("creates a NodeReplacement for example-worker-1", func() {
+			It("creates a NodeReplacement for example-worker-1", func() {
 				checkForNodeReplacement("example-worker-1", workerNode1, 10)
 			})
 
@@ -231,15 +233,16 @@ var _ = Describe("Handler suite", func() {
 				m.Get(nr, consistentlyTimeout).ShouldNot(Succeed())
 			})
 
-			PIt("populates the Result ReplacementsCreated field", func() {
+			It("populates the Result ReplacementsCreated field", func() {
 				Expect(result.ReplacementsCreated).To(ConsistOf(
 					"example-master-1",
 					"example-worker-1",
 				))
 			})
 
-			PIt("sets the Result Phase to InProgress", func() {
-				Expect(result.Phase).To(Equal(navarchosv1alpha1.RolloutPhaseInProgress))
+			It("sets the Result Phase to InProgress", func() {
+				inProgress := navarchosv1alpha1.RolloutPhaseInProgress
+				Expect(result.Phase).To(Equal(&inProgress))
 			})
 
 			It("does not set the Result ReplacementsCompleted field", func() {
@@ -258,19 +261,19 @@ var _ = Describe("Handler suite", func() {
 				Expect(nodeRollout).To(utils.WithNodeRolloutSpecField("NodeSelectors", Not(BeEmpty())))
 			})
 
-			PIt("creates a NodeReplacement for example-master-1", func() {
+			It("creates a NodeReplacement for example-master-1", func() {
 				checkForNodeReplacement("example-master-1", masterNode1, 20)
 			})
 
-			PIt("creates a NodeReplacement for example-master-2", func() {
+			It("creates a NodeReplacement for example-master-2", func() {
 				checkForNodeReplacement("example-master-2", masterNode2, 15)
 			})
 
-			PIt("creates a NodeReplacement for example-worker-1", func() {
+			It("creates a NodeReplacement for example-worker-1", func() {
 				checkForNodeReplacement("example-worker-1", workerNode1, 10)
 			})
 
-			PIt("creates a NodeReplacement for example-worker-2", func() {
+			It("creates a NodeReplacement for example-worker-2", func() {
 				checkForNodeReplacement("example-worker-2", workerNode2, 5)
 			})
 
@@ -283,7 +286,7 @@ var _ = Describe("Handler suite", func() {
 				m.Get(nr, consistentlyTimeout).ShouldNot(Succeed())
 			})
 
-			PIt("populates the Result ReplacementsCreated field", func() {
+			It("populates the Result ReplacementsCreated field", func() {
 				Expect(result.ReplacementsCreated).To(ConsistOf(
 					"example-master-1",
 					"example-master-2",
@@ -292,8 +295,9 @@ var _ = Describe("Handler suite", func() {
 				))
 			})
 
-			PIt("sets the Result Phase to InProgress", func() {
-				Expect(result.Phase).To(Equal(navarchosv1alpha1.RolloutPhaseInProgress))
+			It("sets the Result Phase to InProgress", func() {
+				inProgress := navarchosv1alpha1.RolloutPhaseInProgress
+				Expect(result.Phase).To(Equal(&inProgress))
 			})
 
 			It("does not set the Result ReplacementsCompleted field", func() {
@@ -326,7 +330,7 @@ var _ = Describe("Handler suite", func() {
 				m.Create(nrWorker1).Should(Succeed())
 			})
 
-			PIt("should create new NodeReplacements for the nodes", func() {
+			It("should create new NodeReplacements for the nodes", func() {
 				nrList := &navarchosv1alpha1.NodeReplacementList{}
 				m.List(nrList, timeout).Should(Succeed())
 
@@ -337,21 +341,21 @@ var _ = Describe("Handler suite", func() {
 
 				Expect(items).To(SatisfyAll(
 					ContainElement(SatisfyAll(
-						utils.WithObjectMetaField("Name", Not(Equal(nrMaster1.GetName()))),
-						utils.WithNodeReplacementSpecField("ReplacementSpec", utils.WithReplacementSpecField("Priority", Equal(20))),
-						utils.WithNodeReplacementSpecField("NodeName", Equal(masterNode1.GetName())),
-						utils.WithNodeReplacementSpecField("NodeUID", Equal(masterNode1.GetUID())),
-						utils.WithObjectMetaField("OwnerReferences", SatisfyAll(
+						utils.WithField("ObjectMeta.Name", Not(Equal(nrMaster1.GetName()))),
+						utils.WithField("Spec.ReplacementSpec.Priority", Equal(intPtr(20))),
+						utils.WithField("Spec.NodeName", Equal(masterNode1.GetName())),
+						utils.WithField("Spec.NodeUID", Equal(masterNode1.GetUID())),
+						utils.WithField("ObjectMeta.OwnerReferences", SatisfyAll(
 							ContainElement(Equal(utils.GetOwnerReferenceForNode(masterNode1))),
 							ContainElement(Equal(utils.GetOwnerReferenceForNodeRollout(nodeRollout))),
 						)),
 					)),
 					ContainElement(SatisfyAll(
-						utils.WithObjectMetaField("Name", Not(Equal(nrWorker1.GetName()))),
-						utils.WithNodeReplacementSpecField("ReplacementSpec", utils.WithReplacementSpecField("Priority", Equal(10))),
-						utils.WithNodeReplacementSpecField("NodeName", Equal(workerNode1.GetName())),
-						utils.WithNodeReplacementSpecField("NodeUID", Equal(workerNode1.GetUID())),
-						utils.WithObjectMetaField("OwnerReferences", SatisfyAll(
+						utils.WithField("ObjectMeta.Name", Not(Equal(nrWorker1.GetName()))),
+						utils.WithField("Spec.ReplacementSpec.Priority", Equal(intPtr(10))),
+						utils.WithField("Spec.NodeName", Equal(workerNode1.GetName())),
+						utils.WithField("Spec.NodeUID", Equal(workerNode1.GetUID())),
+						utils.WithField("ObjectMeta.OwnerReferences", SatisfyAll(
 							ContainElement(Equal(utils.GetOwnerReferenceForNode(workerNode1))),
 							ContainElement(Equal(utils.GetOwnerReferenceForNodeRollout(nodeRollout))),
 						)),
@@ -476,3 +480,7 @@ var _ = Describe("Handler suite", func() {
 
 	})
 })
+
+func intPtr(i int) *int {
+	return &i
+}

--- a/pkg/controller/noderollout/status/status.go
+++ b/pkg/controller/noderollout/status/status.go
@@ -26,7 +26,7 @@ func UpdateStatus(c client.Client, instance *navarchosv1alpha1.NodeRollout, resu
 	}
 
 	setReplacementsCompleted(&status, result)
-	err = setCondition(&status, navarchosv1alpha1.ReplacementsCreatedType, result.ReplacementsCompletedError, result.ReplacementsCompletedReason)
+	err = setCondition(&status, navarchosv1alpha1.ReplacementsCreatedType, result.ReplacementsCreatedError, result.ReplacementsCreatedReason)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/noderollout/status/status_test.go
+++ b/pkg/controller/noderollout/status/status_test.go
@@ -178,7 +178,7 @@ var _ = Describe("NodeRollout Status Suite", func() {
 			})
 		})
 
-		Context("when the ReplacementsCompletedError is not set in the Result", func() {
+		Context("when the ReplacementsCreatedError is not set in the Result", func() {
 			It("updates the status condition", func() {
 				m.Eventually(nodeRollout, timeout).Should(
 					utils.WithNodeRolloutStatusField("Conditions",
@@ -197,10 +197,10 @@ var _ = Describe("NodeRollout Status Suite", func() {
 			})
 		})
 
-		Context("when the ReplacementsCompletedError is set in the Result", func() {
+		Context("when the ReplacementsCreatedError is set in the Result", func() {
 			BeforeEach(func() {
-				result.ReplacementsCompletedError = errors.New("error creating replacements")
-				result.ReplacementsCompletedReason = "CompletedErrorReason"
+				result.ReplacementsCreatedError = errors.New("error creating replacements")
+				result.ReplacementsCreatedReason = "CreatedErrorReason"
 			})
 
 			It("updates the status condition", func() {
@@ -209,8 +209,8 @@ var _ = Describe("NodeRollout Status Suite", func() {
 						ContainElement(SatisfyAll(
 							utils.WithNodeRolloutConditionField("Type", Equal(navarchosv1alpha1.ReplacementsCreatedType)),
 							utils.WithNodeRolloutConditionField("Status", Equal(corev1.ConditionFalse)),
-							utils.WithNodeRolloutConditionField("Reason", Equal(result.ReplacementsCompletedReason)),
-							utils.WithNodeRolloutConditionField("Message", Equal(result.ReplacementsCompletedError.Error())),
+							utils.WithNodeRolloutConditionField("Reason", Equal(result.ReplacementsCreatedReason)),
+							utils.WithNodeRolloutConditionField("Message", Equal(result.ReplacementsCreatedError.Error())),
 						)),
 					),
 				)
@@ -221,10 +221,10 @@ var _ = Describe("NodeRollout Status Suite", func() {
 			})
 		})
 
-		Context("ReplacementsCompletedError and ReplacementsCompletedReason must be set together", func() {
+		Context("ReplacementsCreatedError and ReplacementsCreatedReason must be set together", func() {
 			Context("if only ReplacementsCompleteError is set", func() {
 				BeforeEach(func() {
-					result.ReplacementsCompletedError = errors.New("error")
+					result.ReplacementsCreatedError = errors.New("error")
 				})
 
 				It("causes an error", func() {
@@ -232,9 +232,9 @@ var _ = Describe("NodeRollout Status Suite", func() {
 				})
 			})
 
-			Context("if only ReplacementsCompleteReason is set", func() {
+			Context("if only ReplacementsCreatedReason is set", func() {
 				BeforeEach(func() {
-					result.ReplacementsCompletedReason = "test"
+					result.ReplacementsCreatedReason = "test"
 				})
 
 				It("causes an error", func() {
@@ -244,8 +244,8 @@ var _ = Describe("NodeRollout Status Suite", func() {
 
 			Context("if both are set", func() {
 				BeforeEach(func() {
-					result.ReplacementsCompletedError = errors.New("error")
-					result.ReplacementsCompletedReason = "test"
+					result.ReplacementsCreatedError = errors.New("error")
+					result.ReplacementsCreatedReason = "test"
 				})
 
 				It("does not cause an error", func() {

--- a/pkg/controller/noderollout/status/types.go
+++ b/pkg/controller/noderollout/status/types.go
@@ -13,7 +13,7 @@ type Result struct {
 	// This should contain any errors related to the creation of the NodeReplacements.
 	ReplacementsCreatedError error
 
-	// This is the short reason description for the errors related to creating of
+	// This is the short reason description for the errors related to creation of
 	// NodeReplacements.
 	ReplacementsCreatedReason navarchosv1alpha1.NodeRolloutConditionReason
 

--- a/pkg/controller/noderollout/status/types.go
+++ b/pkg/controller/noderollout/status/types.go
@@ -11,11 +11,11 @@ type Result struct {
 	Phase *navarchosv1alpha1.NodeRolloutPhase
 
 	// This should contain any errors related to the creation of the NodeReplacements.
-	ReplacementsCompletedError error
+	ReplacementsCreatedError error
 
-	// This is the short reason description for the errors related to creationg of
+	// This is the short reason description for the errors related to creating of
 	// NodeReplacements.
-	ReplacementsCompletedReason navarchosv1alpha1.NodeRolloutConditionReason
+	ReplacementsCreatedReason navarchosv1alpha1.NodeRolloutConditionReason
 
 	// This should list all NodeReplacements created.
 	// This will be a list of the node names that are going to be replaced.

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -295,6 +295,9 @@ func WithField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher 
 	return gomega.WithTransform(func(obj interface{}) interface{} {
 		r := reflect.ValueOf(obj)
 		f := reflect.Indirect(r).FieldByName(fields[0])
+		if !f.IsValid() {
+			panic(fmt.Sprintf("Object '%s' does not have a field '%s'", reflect.TypeOf(obj), fields[0]))
+		}
 		return f.Interface()
 	}, matcher)
 }


### PR DESCRIPTION
Implement Handler for New NodeRollouts

This PR implements handling of new `NodeRollout`s in the `NodeRollout` controller. It creates `NodeReplacement`s based on the spec provided.