### PR TITLE
[IS-672] - Ensure each NodeRollout only creates one NodeReplacement per Node

### DIFF
--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -117,8 +117,16 @@ func (m *Matcher) List(obj runtime.Object, intervals ...interface{}) gomega.Gome
 }
 
 // Consistently continually gets the object from the API for comparison
-func (m *Matcher) Consistently(obj Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
-	return m.consistentlyObject(obj, intervals...)
+func (m *Matcher) Consistently(obj runtime.Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+	// If the object is a list, return a list
+	if meta.IsListType(obj) {
+		return m.consistentlyList(obj, intervals...)
+	}
+	if o, ok := obj.(Object); ok {
+		return m.consistentlyObject(o, intervals...)
+	}
+	//Should not get here
+	panic("Unknown object.")
 }
 
 // consistentlyObject gets an individual object from the API server
@@ -135,6 +143,18 @@ func (m *Matcher) consistentlyObject(obj Object, intervals ...interface{}) gomeg
 		return obj
 	}
 	return gomega.Consistently(get, intervals...)
+}
+
+// consistentlyObject gets an individual object from the API server
+func (m *Matcher) consistentlyList(obj runtime.Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+	list := func() runtime.Object {
+		err := m.Client.List(context.TODO(), obj)
+		if err != nil {
+			panic(err)
+		}
+		return obj
+	}
+	return gomega.Consistently(list, intervals...)
 }
 
 // Eventually continually gets the object from the API for comparison


### PR DESCRIPTION
During sanity checking @JoelSpeed and I noticed that two `NodeReplacement`s were being created for every node specified. This happened because there was no validation when creating `NodeReplacement`s. Now it is checked that there is no existing `NodeReplacement` that has the same `NodeRollout` owner. 

This fixes the duplication problem.