### PR TITLE
[IS-683] - Add Completion Timestamp to NodeRollouts and NodeReplacements

### DIFF
--- a/config/crds/navarchos_v1alpha1_nodereplacement.yaml
+++ b/config/crds/navarchos_v1alpha1_nodereplacement.yaml
@@ -47,6 +47,11 @@ spec:
           type: object
         status:
           properties:
+            completionTimestamp:
+              description: CompletionTimestamp is a timestamp for when the replacement
+                has completed
+              format: date-time
+              type: string
             conditions:
               description: Conditions gives detailed condition information about the
                 NodeReplacement

--- a/config/crds/navarchos_v1alpha1_noderollout.yaml
+++ b/config/crds/navarchos_v1alpha1_noderollout.yaml
@@ -81,6 +81,11 @@ spec:
           type: object
         status:
           properties:
+            completionTimestamp:
+              description: CompletionTimestamp is a timestamp for when the rollout
+                has completed
+              format: date-time
+              type: string
             conditions:
               description: Conditions gives detailed condition information about the
                 NodeRollout

--- a/pkg/apis/navarchos/v1alpha1/nodereplacement_types.go
+++ b/pkg/apis/navarchos/v1alpha1/nodereplacement_types.go
@@ -84,6 +84,9 @@ type NodeReplacementStatus struct {
 	// FailedPodsCount is the count of FailedPods.
 	FailedPodsCount int `json:"failedPodsCount,omitempty"`
 
+	// CompletionTimestamp is a timestamp for when the replacement has completed
+	CompletionTimestamp *metav1.Time `json:"completionTimestamp,omitempty"`
+
 	// Conditions gives detailed condition information about the NodeReplacement
 	Conditions []NodeReplacementCondition `json:"conditions,omitempty"`
 }

--- a/pkg/apis/navarchos/v1alpha1/noderollout_types.go
+++ b/pkg/apis/navarchos/v1alpha1/noderollout_types.go
@@ -79,7 +79,7 @@ type NodeRolloutStatus struct {
 	ReplacementsCompletedCount int `json:"replacementsCompletedCount,omitempty"`
 
 	// CompletionTimestamp is a timestamp for when the rollout has completed
-	CompletionTimestamp metav1.Time `json:"completionTimestamp,omitempty"`
+	CompletionTimestamp *metav1.Time `json:"completionTimestamp,omitempty"`
 
 	// Conditions gives detailed condition information about the NodeRollout
 	Conditions []NodeRolloutCondition `json:"conditions,omitempty"`

--- a/pkg/apis/navarchos/v1alpha1/noderollout_types.go
+++ b/pkg/apis/navarchos/v1alpha1/noderollout_types.go
@@ -78,6 +78,9 @@ type NodeRolloutStatus struct {
 	// This is used for printing in kubectl.
 	ReplacementsCompletedCount int `json:"replacementsCompletedCount,omitempty"`
 
+	// CompletionTimestamp is a timestamp for when the rollout has completed
+	CompletionTimestamp metav1.Time `json:"completionTimestamp,omitempty"`
+
 	// Conditions gives detailed condition information about the NodeRollout
 	Conditions []NodeRolloutCondition `json:"conditions,omitempty"`
 }

--- a/pkg/apis/navarchos/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/navarchos/v1alpha1/zz_generated.deepcopy.go
@@ -177,6 +177,10 @@ func (in *NodeReplacementStatus) DeepCopyInto(out *NodeReplacementStatus) {
 		*out = make([]PodReason, len(*in))
 		copy(*out, *in)
 	}
+	if in.CompletionTimestamp != nil {
+		in, out := &in.CompletionTimestamp, &out.CompletionTimestamp
+		*out = (*in).DeepCopy()
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]NodeReplacementCondition, len(*in))
@@ -318,6 +322,10 @@ func (in *NodeRolloutStatus) DeepCopyInto(out *NodeRolloutStatus) {
 		in, out := &in.ReplacementsCompleted, &out.ReplacementsCompleted
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.CompletionTimestamp != nil {
+		in, out := &in.CompletionTimestamp, &out.CompletionTimestamp
+		*out = (*in).DeepCopy()
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions

--- a/pkg/controller/nodereplacement/status/status.go
+++ b/pkg/controller/nodereplacement/status/status.go
@@ -33,6 +33,11 @@ func UpdateStatus(c client.Client, instance *navarchosv1alpha1.NodeReplacement, 
 
 	setFailedPods(&status, result)
 
+	err = setCompletionTimestamp(&status, result)
+	if err != nil {
+		return err
+	}
+
 	err = setCondition(&status, navarchosv1alpha1.NodeCordonedType, result.NodeCordonError, result.NodeCordonReason)
 	if err != nil {
 		return err
@@ -107,6 +112,20 @@ func setFailedPods(status *navarchosv1alpha1.NodeReplacementStatus, result *Resu
 		status.FailedPods = result.FailedPods
 		status.FailedPodsCount = len(result.FailedPods)
 	}
+}
+
+// setCompletionTimestamp sets the setCompletionTimestamp field. If it has not
+// been set before it is added. If it has been set before an error is returned
+func setCompletionTimestamp(status *navarchosv1alpha1.NodeReplacementStatus, result *Result) error {
+	if status.CompletionTimestamp != nil && result.CompletionTimestamp != nil {
+		return fmt.Errorf("cannot update CompletionTimestamp, field is immutable once set")
+	}
+
+	if status.CompletionTimestamp == nil && result.CompletionTimestamp != nil {
+		status.CompletionTimestamp = result.CompletionTimestamp
+	}
+
+	return nil
 }
 
 // newNodeReplacementCondition creates a new condition NodeReplacementCondition

--- a/pkg/controller/nodereplacement/status/status_test.go
+++ b/pkg/controller/nodereplacement/status/status_test.go
@@ -9,6 +9,7 @@ import (
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
 	"github.com/pusher/navarchos/test/utils"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -303,6 +304,64 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 
 			It("does not cause an error", func() {
 				Expect(updateErr).To(BeNil())
+			})
+		})
+
+		Context("when no existing CompletionTimestamp is set", func() {
+			var completionTimestamp metav1.Time
+
+			Context("and there is a CompletionTimestamp set in the Result", func() {
+				BeforeEach(func() {
+					completionTimestamp = metav1.Now()
+					Expect(nodeReplacement.Status.CompletionTimestamp).To(BeNil())
+					result.CompletionTimestamp = &completionTimestamp
+				})
+
+				It("sets the CompletionTimestamp field", func() {
+					m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.CompletionTimestamp", Equal(&completionTimestamp)))
+				})
+
+				It("does not cause an error", func() {
+					Expect(updateErr).To(BeNil())
+				})
+			})
+
+			Context("and there is not a CompletionTimestamp set in the Result", func() {
+				BeforeEach(func() {
+					Expect(nodeReplacement.Status.CompletionTimestamp).To(BeNil())
+				})
+
+				It("does not set the CompletionTimestamp", func() {
+					m.Consistently(nodeReplacement, consistentlyTimeout).Should(utils.WithField("Status.CompletionTimestamp", BeNil()))
+				})
+			})
+
+		})
+
+		Context("when an existing CompletionTimestamp is set and CompletionTimestamp is set in the Result", func() {
+			var completionTimestamp metav1.Time
+			var existingCompletionTimestamp metav1.Time
+
+			BeforeEach(func() {
+				// Set up the existing expected state
+				existingCompletionTimestamp = metav1.NewTime(metav1.Now().Add(-time.Hour))
+				m.Update(nodeReplacement, func(obj utils.Object) utils.Object {
+					nr, _ := obj.(*navarchosv1alpha1.NodeReplacement)
+					nr.Status.CompletionTimestamp = &existingCompletionTimestamp
+					return nr
+				}, timeout).Should(Succeed())
+
+				completionTimestamp = metav1.Now()
+				result.CompletionTimestamp = &completionTimestamp
+			})
+
+			It("does not update the CompletionTimestamp field", func() {
+				m.Consistently(nodeReplacement, consistentlyTimeout).Should(utils.WithField("Status.CompletionTimestamp", Equal(&existingCompletionTimestamp)))
+			})
+
+			It("returns an error", func() {
+				Expect(updateErr).ToNot(BeNil())
+				Expect(updateErr.Error()).To(Equal("cannot update CompletionTimestamp, field is immutable once set"))
 			})
 		})
 

--- a/pkg/controller/nodereplacement/status/types.go
+++ b/pkg/controller/nodereplacement/status/types.go
@@ -14,7 +14,7 @@ type Result struct {
 	Phase *navarchosv1alpha1.NodeReplacementPhase
 
 	// CompletionTimestamp is a timestamp for when the rollout has completed
-	CompletionTimestamp metav1.Time
+	CompletionTimestamp *metav1.Time
 
 	// This allows the Handler to requeue the object before starting if there is
 	// a higher priority NodeReplacement to reconcile

--- a/pkg/controller/nodereplacement/status/types.go
+++ b/pkg/controller/nodereplacement/status/types.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Result is used as the basis to updating the status of the NodeReplacement.
@@ -11,6 +12,9 @@ type Result struct {
 	// set to when updating the status.
 	// If Phase == nil, don't update the Phase, else, overwrite it.
 	Phase *navarchosv1alpha1.NodeReplacementPhase
+
+	// CompletionTimestamp is a timestamp for when the rollout has completed
+	CompletionTimestamp metav1.Time
 
 	// This allows the Handler to requeue the object before starting if there is
 	// a higher priority NodeReplacement to reconcile

--- a/pkg/controller/noderollout/handler/handler_test.go
+++ b/pkg/controller/noderollout/handler/handler_test.go
@@ -520,9 +520,10 @@ var _ = Describe("Handler suite", func() {
 			})
 		})
 
-		Context("and the NodeRollout is older than the maximum age", func() {
+		Context("and the NodeRollout was marked completed more than the maximum age ago", func() {
 			BeforeEach(func() {
-				nodeRollout.CreationTimestamp = metav1.NewTime(time.Now().Add(-h.maxAge - time.Hour))
+				time := metav1.NewTime(time.Now().Add(-h.maxAge - time.Hour))
+				nodeRollout.Status.CompletionTimestamp = &time
 			})
 
 			PIt("deletes the NodeRollout", func() {

--- a/pkg/controller/noderollout/handler/in_progress.go
+++ b/pkg/controller/noderollout/handler/in_progress.go
@@ -32,7 +32,9 @@ func (h *NodeRolloutHandler) handleInProgress(instance *navarchosv1alpha1.NodeRo
 	if len(completed) == len(nodeReplacementList.Items) {
 		completedPhase := navarchosv1alpha1.RolloutPhaseCompleted
 		result.Phase = &completedPhase
-		result.CompletionTimestamp = metav1.Now()
+
+		now := metav1.Now()
+		result.CompletionTimestamp = &now
 	}
 	return result
 }

--- a/pkg/controller/noderollout/handler/in_progress.go
+++ b/pkg/controller/noderollout/handler/in_progress.go
@@ -6,6 +6,7 @@ import (
 
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
 	"github.com/pusher/navarchos/pkg/controller/noderollout/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // handleInProgress handles a NodeRollout in the 'InProgress' phase. It checks
@@ -31,6 +32,7 @@ func (h *NodeRolloutHandler) handleInProgress(instance *navarchosv1alpha1.NodeRo
 	if len(completed) == len(nodeReplacementList.Items) {
 		completedPhase := navarchosv1alpha1.RolloutPhaseCompleted
 		result.Phase = &completedPhase
+		result.CompletionTimestamp = metav1.Now()
 	}
 	return result
 }

--- a/pkg/controller/noderollout/status/status.go
+++ b/pkg/controller/noderollout/status/status.go
@@ -27,6 +27,11 @@ func UpdateStatus(c client.Client, instance *navarchosv1alpha1.NodeRollout, resu
 
 	setReplacementsCompleted(&status, result)
 
+	err = setCompletionTimestamp(&status, result)
+	if err != nil {
+		return err
+	}
+
 	err = setCondition(&status, navarchosv1alpha1.ReplacementsCreatedType, result.ReplacementsCreatedError, result.ReplacementsCreatedReason)
 	if err != nil {
 		return err
@@ -83,6 +88,21 @@ func setReplacementsCompleted(status *navarchosv1alpha1.NodeRolloutStatus, resul
 		status.ReplacementsCompleted = result.ReplacementsCompleted
 		status.ReplacementsCompletedCount = len(result.ReplacementsCompleted)
 	}
+
+}
+
+// setCompletionTimestamp sets the setCompletionTimestamp field. If it has not
+// been set before it is added. If it has been set before an error is returned
+func setCompletionTimestamp(status *navarchosv1alpha1.NodeRolloutStatus, result *Result) error {
+	if status.CompletionTimestamp != nil && result.CompletionTimestamp != nil {
+		return fmt.Errorf("cannot update CompletionTimestamp, field is immutable once set")
+	}
+
+	if status.CompletionTimestamp == nil && result.CompletionTimestamp != nil {
+		status.CompletionTimestamp = result.CompletionTimestamp
+	}
+
+	return nil
 
 }
 

--- a/pkg/controller/noderollout/status/types.go
+++ b/pkg/controller/noderollout/status/types.go
@@ -1,6 +1,9 @@
 package status
 
-import navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
+import (
+	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // Result is used as the basis to updating the status of the NodeRollout.
 // It contains information gathered during a single run of the reconcile loop.
@@ -35,4 +38,7 @@ type Result struct {
 	// does not exist on the cluster.
 	// This list will be merged with the existing status list.
 	ReplacementsCompleted []string
+
+	// CompletionTimestamp is a timestamp for when the rollout has completed
+	CompletionTimestamp metav1.Time
 }

--- a/pkg/controller/noderollout/status/types.go
+++ b/pkg/controller/noderollout/status/types.go
@@ -40,5 +40,5 @@ type Result struct {
 	ReplacementsCompleted []string
 
 	// CompletionTimestamp is a timestamp for when the rollout has completed
-	CompletionTimestamp metav1.Time
+	CompletionTimestamp *metav1.Time
 }


### PR DESCRIPTION
This PR adds a completion timestamp to `NodeRollouts` and `NodeReplacements`. 

This provides the data for the handler for completed `NodeRollouts` and `NodeReplacements` to delete them automatically after a given time period