### PR TITLE
Allow NodeReplacement handler to return errors

### DIFF
--- a/pkg/controller/nodereplacement/handler/handler.go
+++ b/pkg/controller/nodereplacement/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"time"
 
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
@@ -40,6 +41,6 @@ func NewNodeReplacementHandler(c client.Client, opts *Options) *NodeReplacementH
 
 // Handle performs the business logic of a NodeReplacement and returns
 // information in a Result
-func (h *NodeReplacementHandler) Handle(instance *navarchosv1alpha1.NodeReplacement) *status.Result {
-	return &status.Result{}
+func (h *NodeReplacementHandler) Handle(instance *navarchosv1alpha1.NodeReplacement) (*status.Result, error) {
+	return &status.Result{}, fmt.Errorf("method not implemented")
 }

--- a/pkg/controller/nodereplacement/nodereplacement_controller.go
+++ b/pkg/controller/nodereplacement/nodereplacement_controller.go
@@ -95,7 +95,10 @@ func (r *ReconcileNodeReplacement) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, err
 	}
 
-	result := r.handler.Handle(instance)
+	result, err := r.handler.Handle(instance)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("error handling replacement %s: %v", instance.GetName(), err)
+	}
 	err = status.UpdateStatus(r.Client, instance, result)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("error updating status: %v", err)


### PR DESCRIPTION
At the moment there is no way for the NodeReplacement handler to return an error and request that the object be requeued for another reconcile.

This modifies the signature and adds tests to check when should an error actually be returned.