### PR TITLE
Allow NodeRollout handler to return errors

### DIFF
--- a/pkg/controller/noderollout/handler/handler.go
+++ b/pkg/controller/noderollout/handler/handler.go
@@ -40,7 +40,7 @@ func NewNodeRolloutHandler(c client.Client, opts *Options) *NodeRolloutHandler {
 
 // Handle performs the business logic of the NodeRollout and returns information
 // in a Result
-func (h *NodeRolloutHandler) Handle(instance *navarchosv1alpha1.NodeRollout) *status.Result {
+func (h *NodeRolloutHandler) Handle(instance *navarchosv1alpha1.NodeRollout) (*status.Result, error) {
 	switch instance.Status.Phase {
 	case navarchosv1alpha1.RolloutPhaseNew:
 		return h.handleNew(instance)
@@ -53,6 +53,6 @@ func (h *NodeRolloutHandler) Handle(instance *navarchosv1alpha1.NodeRollout) *st
 	}
 }
 
-func (h *NodeRolloutHandler) handleCompleted(instance *navarchosv1alpha1.NodeRollout) *status.Result {
-	return &status.Result{}
+func (h *NodeRolloutHandler) handleCompleted(instance *navarchosv1alpha1.NodeRollout) (*status.Result, error) {
+	return &status.Result{}, nil
 }

--- a/pkg/controller/noderollout/handler/handler_test.go
+++ b/pkg/controller/noderollout/handler/handler_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Handler suite", func() {
 	var h *NodeRolloutHandler
 	var opts *Options
 	var result *status.Result
+	var handleErr error
 
 	var nodeRollout *navarchosv1alpha1.NodeRollout
 	var mgrStopped *sync.WaitGroup
@@ -137,7 +138,7 @@ var _ = Describe("Handler suite", func() {
 
 	Context("when the Handler function is called on a New NodeRollout", func() {
 		JustBeforeEach(func() {
-			result = h.Handle(nodeRollout)
+			result, handleErr = h.Handle(nodeRollout)
 		})
 
 		Context("with NodeSelectors only", func() {
@@ -197,6 +198,10 @@ var _ = Describe("Handler suite", func() {
 			It("does not set any error", func() {
 				Expect(result.ReplacementsCreatedError).To(BeNil())
 				Expect(result.ReplacementsCreatedReason).To(BeEmpty())
+			})
+
+			It("should not return an error", func() {
+				Expect(handleErr).ToNot(HaveOccurred())
 			})
 		})
 
@@ -266,6 +271,10 @@ var _ = Describe("Handler suite", func() {
 				Expect(result.ReplacementsCreatedError).To(BeNil())
 				Expect(result.ReplacementsCreatedReason).To(BeEmpty())
 			})
+
+			It("should not return an error", func() {
+				Expect(handleErr).ToNot(HaveOccurred())
+			})
 		})
 
 		Context("with NodeNames and NodeSelectors", func() {
@@ -320,6 +329,10 @@ var _ = Describe("Handler suite", func() {
 			It("does not set any error", func() {
 				Expect(result.ReplacementsCreatedError).To(BeNil())
 				Expect(result.ReplacementsCreatedReason).To(BeEmpty())
+			})
+
+			It("should not return an error", func() {
+				Expect(handleErr).ToNot(HaveOccurred())
 			})
 		})
 
@@ -436,7 +449,7 @@ var _ = Describe("Handler suite", func() {
 		})
 
 		JustBeforeEach(func() {
-			result = h.Handle(nodeRollout)
+			result, handleErr = h.Handle(nodeRollout)
 		})
 
 		Context("if nothing has changed", func() {
@@ -511,7 +524,7 @@ var _ = Describe("Handler suite", func() {
 		})
 
 		JustBeforeEach(func() {
-			result = h.Handle(nodeRollout)
+			result, handleErr = h.Handle(nodeRollout)
 		})
 
 		Context("and the NodeRollout is younger than the maximum age", func() {

--- a/pkg/controller/noderollout/handler/in_progress.go
+++ b/pkg/controller/noderollout/handler/in_progress.go
@@ -13,7 +13,7 @@ import (
 // the number of completed NodeReplacements, and updates the result. If all
 // replacements are completed it updates the status of the NodeReplacement to
 // 'Complete'
-func (h *NodeRolloutHandler) handleInProgress(instance *navarchosv1alpha1.NodeRollout) *status.Result {
+func (h *NodeRolloutHandler) handleInProgress(instance *navarchosv1alpha1.NodeRollout) (*status.Result, error) {
 	result := &status.Result{
 		ReplacementsInProgressReason: "StillProgressing",
 	}
@@ -23,7 +23,7 @@ func (h *NodeRolloutHandler) handleInProgress(instance *navarchosv1alpha1.NodeRo
 	if err != nil {
 		result.ReplacementsInProgressError = fmt.Errorf("failed to list NodeReplacements: %v", err)
 		result.ReplacementsInProgressReason = "ErrorListingNodes"
-		return result
+		return result, result.ReplacementsInProgressError
 	}
 
 	completed := completedNodeReplacements(nodeReplacementList.Items)
@@ -36,7 +36,7 @@ func (h *NodeRolloutHandler) handleInProgress(instance *navarchosv1alpha1.NodeRo
 		now := metav1.Now()
 		result.CompletionTimestamp = &now
 	}
-	return result
+	return result, nil
 }
 
 // completedNodeReplacements takes a slice of replacements and returns a list of the nodes'

--- a/pkg/controller/noderollout/noderollout_controller.go
+++ b/pkg/controller/noderollout/noderollout_controller.go
@@ -104,7 +104,10 @@ func (r *ReconcileNodeRollout) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	result := r.handler.Handle(instance)
+	result, err := r.handler.Handle(instance)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("error handling rollout %s: %+v", instance.GetName(), err)
+	}
 	err = status.UpdateStatus(r.Client, instance, result)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("error updating status: %v", err)


### PR DESCRIPTION
At the moment there is no way for the NodeRollout handler to return an error and request that the object be re-queued for another reconcile.

This modifies the signature and adds tests to check when should an error actually be returned.