### PR TITLE
[IS-697] - Migrate testing to use WithField matcher

### DIFF
--- a/pkg/controller/nodereplacement/handler/handler_test.go
+++ b/pkg/controller/nodereplacement/handler/handler_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Handler suite", func() {
 					nr.Spec.ReplacementSpec.Priority = intPtr(0)
 					return nr
 				}, timeout).Should(Succeed())
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementSpecField("ReplacementSpec", utils.WithReplacementSpecField("Priority", Equal(intPtr(0)))))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Spec.ReplacementSpec.Priority", Equal(intPtr(0))))
 				Expect(*highPriorityNR.Spec.ReplacementSpec.Priority).To(BeNumerically(">", *nodeReplacement.Spec.ReplacementSpec.Priority))
 			})
 
@@ -183,7 +183,7 @@ var _ = Describe("Handler suite", func() {
 					nr.Spec.ReplacementSpec.Priority = intPtr(10)
 					return nr
 				}, timeout).Should(Succeed())
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementSpecField("ReplacementSpec", utils.WithReplacementSpecField("Priority", Equal(intPtr(10)))))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Spec.ReplacementSpec.Priority", Equal(intPtr(10))))
 				Expect(*samePriorityNR.Spec.ReplacementSpec.Priority).To(BeNumerically("==", *nodeReplacement.Spec.ReplacementSpec.Priority))
 			})
 
@@ -233,11 +233,11 @@ var _ = Describe("Handler suite", func() {
 		})
 
 		PIt("should cordon the node", func() {
-			m.Eventually(workerNode1, timeout).Should(utils.WithNodeSpecField("Unschedulable", BeTrue()))
-			m.Eventually(workerNode1, timeout).Should(utils.WithNodeSpecField("Taints",
+			m.Eventually(workerNode1, timeout).Should(utils.WithField("Spec.Unschedulable", BeTrue()))
+			m.Eventually(workerNode1, timeout).Should(utils.WithField("Spec.Taints",
 				ContainElement(SatisfyAll(
-					utils.WithTaintField("Effect", Equal("NoSchedule")),
-					utils.WithTaintField("Key", Equal("node.kubernetes.io/unschedulable")),
+					utils.WithField("Effect", Equal("NoSchedule")),
+					utils.WithField("Key", Equal("node.kubernetes.io/unschedulable")),
 				)),
 			))
 		})
@@ -256,7 +256,7 @@ var _ = Describe("Handler suite", func() {
 
 		It("should not evict any pods", func() {
 			for _, pod := range []*corev1.Pod{pod1, pod2, pod3, pod4} {
-				m.Consistently(pod).Should(utils.WithObjectMetaField("DeletionTimestamp", BeNil()))
+				m.Consistently(pod).Should(utils.WithField("ObjectMeta.DeletionTimestamp", BeNil()))
 			}
 		})
 
@@ -308,12 +308,12 @@ var _ = Describe("Handler suite", func() {
 
 		PIt("evicts all pods in the NodePods list", func() {
 			for _, pod := range []*corev1.Pod{pod1, pod2, pod3} {
-				m.Eventually(pod, timeout).ShouldNot(utils.WithObjectMetaField("DeletionTimestamp", BeNil()))
+				m.Eventually(pod, timeout).ShouldNot(utils.WithField("ObjectMeta.DeletionTimestamp", BeNil()))
 			}
 		})
 
 		It("does not evict pods not listed in the NodePods list", func() {
-			m.Consistently(pod4, consistentlyTimeout).Should(utils.WithObjectMetaField("DeletionTimestamp", BeNil()))
+			m.Consistently(pod4, consistentlyTimeout).Should(utils.WithField("ObjectMeta.DeletionTimestamp", BeNil()))
 		})
 
 		PIt("adds evicted pods to the Result EvictedPods field", func() {
@@ -382,7 +382,7 @@ var _ = Describe("Handler suite", func() {
 				})
 
 				It("does not delete the node", func() {
-					m.Consistently(workerNode1).Should(utils.WithObjectMetaField("DeletionTimestamp", BeNil()))
+					m.Consistently(workerNode1).Should(utils.WithField("ObjectMeta.DeletionTimestamp", BeNil()))
 				})
 
 				PIt("should return an error", func() {

--- a/pkg/controller/nodereplacement/status/status_test.go
+++ b/pkg/controller/nodereplacement/status/status_test.go
@@ -58,7 +58,7 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 			})
 
 			It("updates the phase in the status", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("Phase", Equal(phase)))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.Phase", Equal(phase)))
 			})
 
 			It("does not cause an error", func() {
@@ -76,11 +76,11 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 			})
 
 			It("sets the NodePods field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("NodePods", Equal(nodePods)))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.NodePods", Equal(nodePods)))
 			})
 
 			It("sets the NodePodsCount field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("NodePodsCount", Equal(len(nodePods))))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.NodePodsCount", Equal(len(nodePods))))
 			})
 
 			It("does not cause an error", func() {
@@ -107,11 +107,11 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 			})
 
 			It("does not update the NodePods field", func() {
-				m.Consistently(nodeReplacement, consistentlyTimeout).Should(utils.WithNodeReplacementStatusField("NodePods", Equal(existingNodePods)))
+				m.Consistently(nodeReplacement, consistentlyTimeout).Should(utils.WithField("Status.NodePods", Equal(existingNodePods)))
 			})
 
 			It("does not update the NodePodsCount field", func() {
-				m.Consistently(nodeReplacement, consistentlyTimeout).Should(utils.WithNodeReplacementStatusField("NodePodsCount", Equal(len(existingNodePods))))
+				m.Consistently(nodeReplacement, consistentlyTimeout).Should(utils.WithField("Status.NodePodsCount", Equal(len(existingNodePods))))
 			})
 
 			It("returns an error", func() {
@@ -129,11 +129,11 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 			})
 
 			It("sets the EvictedPods field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("EvictedPods", Equal(evictedPods)))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.EvictedPods", Equal(evictedPods)))
 			})
 
 			It("sets the EvictedPodsCount field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("EvictedPodsCount", Equal(len(evictedPods))))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.EvictedPodsCount", Equal(len(evictedPods))))
 			})
 
 			It("does not cause an error", func() {
@@ -164,12 +164,12 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 
 			It("joins the new and existing EvictedPods field", func() {
 				m.Eventually(nodeReplacement, timeout).Should(
-					utils.WithNodeReplacementStatusField("EvictedPods", ConsistOf(expectedEvictedPods)),
+					utils.WithField("Status.EvictedPods", ConsistOf(expectedEvictedPods)),
 				)
 			})
 
 			It("updates the EvictedPodsCount field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("EvictedPodsCount", Equal(len(expectedEvictedPods))))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.EvictedPodsCount", Equal(len(expectedEvictedPods))))
 			})
 
 			It("does not cause an error", func() {
@@ -192,11 +192,11 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 			})
 
 			It("sets the IgnoredPods field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("IgnoredPods", Equal(ignoredPods)))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.IgnoredPods", Equal(ignoredPods)))
 			})
 
 			It("sets the IgnoredPodsCount field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("IgnoredPodsCount", Equal(len(ignoredPods))))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.IgnoredPodsCount", Equal(len(ignoredPods))))
 			})
 
 			It("does not cause an error", func() {
@@ -231,11 +231,11 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 			})
 
 			It("does not update the IgnoredPods field", func() {
-				m.Consistently(nodeReplacement, consistentlyTimeout).Should(utils.WithNodeReplacementStatusField("IgnoredPods", Equal(existingIgnoredPods)))
+				m.Consistently(nodeReplacement, consistentlyTimeout).Should(utils.WithField("Status.IgnoredPods", Equal(existingIgnoredPods)))
 			})
 
 			It("does not update the IgnoredPodsCount field", func() {
-				m.Consistently(nodeReplacement, consistentlyTimeout).Should(utils.WithNodeReplacementStatusField("IgnoredPodsCount", Equal(len(existingIgnoredPods))))
+				m.Consistently(nodeReplacement, consistentlyTimeout).Should(utils.WithField("Status.IgnoredPodsCount", Equal(len(existingIgnoredPods))))
 			})
 
 			It("returns an error", func() {
@@ -258,11 +258,11 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 			})
 
 			It("sets the FailedPods field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("FailedPods", Equal(failedPods)))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.FailedPods", Equal(failedPods)))
 			})
 
 			It("sets the FailedPodsCount field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("FailedPodsCount", Equal(len(failedPods))))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.FailedPodsCount", Equal(len(failedPods))))
 			})
 
 			It("does not cause an error", func() {
@@ -295,11 +295,11 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 			})
 
 			It("updates the FailedPods field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("FailedPods", Equal(failedPods)))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.FailedPods", Equal(failedPods)))
 			})
 
 			It("updates the FailedPodsCount field", func() {
-				m.Eventually(nodeReplacement, timeout).Should(utils.WithNodeReplacementStatusField("FailedPodsCount", Equal(len(failedPods))))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.FailedPodsCount", Equal(len(failedPods))))
 			})
 
 			It("does not cause an error", func() {
@@ -414,12 +414,12 @@ var _ = Describe("NodeReplacement Status Suite", func() {
 
 			It("updates the status condition", func() {
 				m.Eventually(nodeReplacement, timeout).Should(
-					utils.WithNodeReplacementStatusField("Conditions",
+					utils.WithField("Status.Conditions",
 						ContainElement(SatisfyAll(
-							utils.WithNodeReplacementConditionField("Type", Equal(navarchosv1alpha1.NodeCordonedType)),
-							utils.WithNodeReplacementConditionField("Status", Equal(corev1.ConditionFalse)),
-							utils.WithNodeReplacementConditionField("Reason", Equal(result.NodeCordonReason)),
-							utils.WithNodeReplacementConditionField("Message", Equal(result.NodeCordonError.Error())),
+							utils.WithField("Type", Equal(navarchosv1alpha1.NodeCordonedType)),
+							utils.WithField("Status", Equal(corev1.ConditionFalse)),
+							utils.WithField("Reason", Equal(result.NodeCordonReason)),
+							utils.WithField("Message", Equal(result.NodeCordonError.Error())),
 						)),
 					),
 				)

--- a/pkg/controller/noderollout/handler/handler_test.go
+++ b/pkg/controller/noderollout/handler/handler_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Handler suite", func() {
 					nr.Spec.NodeNames = []navarchosv1alpha1.NodeName{}
 					return nr
 				}, timeout).Should(Succeed())
-				Expect(nodeRollout).To(utils.WithNodeRolloutSpecField("NodeNames", BeEmpty()))
+				Expect(nodeRollout).To(utils.WithField("Spec.NodeNames", BeEmpty()))
 			})
 
 			It("creates a NodeReplacement for example-master-1", func() {
@@ -213,7 +213,7 @@ var _ = Describe("Handler suite", func() {
 					nr.Spec.NodeSelectors = []navarchosv1alpha1.NodeLabelSelector{}
 					return nr
 				}, timeout).Should(Succeed())
-				Expect(nodeRollout).To(utils.WithNodeRolloutSpecField("NodeSelectors", BeEmpty()))
+				Expect(nodeRollout).To(utils.WithField("Spec.NodeSelectors", BeEmpty()))
 			})
 
 			It("creates a NodeReplacement for example-master-1", func() {
@@ -279,8 +279,8 @@ var _ = Describe("Handler suite", func() {
 
 		Context("with NodeNames and NodeSelectors", func() {
 			BeforeEach(func() {
-				Expect(nodeRollout).To(utils.WithNodeRolloutSpecField("NodeNames", Not(BeEmpty())))
-				Expect(nodeRollout).To(utils.WithNodeRolloutSpecField("NodeSelectors", Not(BeEmpty())))
+				Expect(nodeRollout).To(utils.WithField("Spec.NodeNames", Not(BeEmpty())))
+				Expect(nodeRollout).To(utils.WithField("Spec.NodeSelectors", Not(BeEmpty())))
 			})
 
 			It("creates a NodeReplacement for example-master-1", func() {
@@ -347,7 +347,7 @@ var _ = Describe("Handler suite", func() {
 					nr.Spec.NodeSelectors = []navarchosv1alpha1.NodeLabelSelector{}
 					return nr
 				}, timeout).Should(Succeed())
-				Expect(nodeRollout).To(utils.WithNodeRolloutSpecField("NodeSelectors", BeEmpty()))
+				Expect(nodeRollout).To(utils.WithField("Spec.NodeSelectors", BeEmpty()))
 
 				By("creating NodeReplacements for the Nodes named in the NodeRollout")
 				nrMaster1 = nodeReplacementFor(masterNode1)

--- a/pkg/controller/noderollout/status/status_test.go
+++ b/pkg/controller/noderollout/status/status_test.go
@@ -59,7 +59,7 @@ var _ = Describe("NodeRollout Status Suite", func() {
 			})
 
 			It("updates the phase in the status", func() {
-				m.Eventually(nodeRollout, timeout).Should(utils.WithNodeRolloutStatusField("Phase", Equal(phase)))
+				m.Eventually(nodeRollout, timeout).Should(utils.WithField("Status.Phase", Equal(phase)))
 			})
 
 			It("does not cause an error", func() {
@@ -77,11 +77,11 @@ var _ = Describe("NodeRollout Status Suite", func() {
 			})
 
 			It("sets the ReplacementsCreated field", func() {
-				m.Eventually(nodeRollout, timeout).Should(utils.WithNodeRolloutStatusField("ReplacementsCreated", Equal(replacementsCreated)))
+				m.Eventually(nodeRollout, timeout).Should(utils.WithField("Status.ReplacementsCreated", Equal(replacementsCreated)))
 			})
 
 			It("sets the ReplacementsCreatedCount field", func() {
-				m.Eventually(nodeRollout, timeout).Should(utils.WithNodeRolloutStatusField("ReplacementsCreatedCount", Equal(len(replacementsCreated))))
+				m.Eventually(nodeRollout, timeout).Should(utils.WithField("Status.ReplacementsCreatedCount", Equal(len(replacementsCreated))))
 			})
 
 			It("does not cause an error", func() {
@@ -108,11 +108,11 @@ var _ = Describe("NodeRollout Status Suite", func() {
 			})
 
 			It("does not update the ReplacementsCreated field", func() {
-				m.Consistently(nodeRollout, consistentlyTimeout).Should(utils.WithNodeRolloutStatusField("ReplacementsCreated", Equal(existingReplacementsCreated)))
+				m.Consistently(nodeRollout, consistentlyTimeout).Should(utils.WithField("Status.ReplacementsCreated", Equal(existingReplacementsCreated)))
 			})
 
 			It("does not update the ReplacementsCreatedCount field", func() {
-				m.Consistently(nodeRollout, consistentlyTimeout).Should(utils.WithNodeRolloutStatusField("ReplacementsCreatedCount", Equal(len(existingReplacementsCreated))))
+				m.Consistently(nodeRollout, consistentlyTimeout).Should(utils.WithField("Status.ReplacementsCreatedCount", Equal(len(existingReplacementsCreated))))
 			})
 
 			It("returns an error", func() {
@@ -131,11 +131,11 @@ var _ = Describe("NodeRollout Status Suite", func() {
 			})
 
 			It("sets the ReplacementsCompleted field", func() {
-				m.Eventually(nodeRollout, timeout).Should(utils.WithNodeRolloutStatusField("ReplacementsCompleted", Equal(replacementsCompleted)))
+				m.Eventually(nodeRollout, timeout).Should(utils.WithField("Status.ReplacementsCompleted", Equal(replacementsCompleted)))
 			})
 
 			It("sets the ReplacementsCompletedCount field", func() {
-				m.Eventually(nodeRollout, timeout).Should(utils.WithNodeRolloutStatusField("ReplacementsCompletedCount", Equal(len(replacementsCompleted))))
+				m.Eventually(nodeRollout, timeout).Should(utils.WithField("Status.ReplacementsCompletedCount", Equal(len(replacementsCompleted))))
 			})
 
 			It("does not cause an error", func() {
@@ -167,12 +167,12 @@ var _ = Describe("NodeRollout Status Suite", func() {
 
 			It("joins the new and existing ReplacementsCompleted field", func() {
 				m.Eventually(nodeRollout, timeout).Should(
-					utils.WithNodeRolloutStatusField("ReplacementsCompleted", ConsistOf(expectedReplacementsCompleted)),
+					utils.WithField("Status.ReplacementsCompleted", ConsistOf(expectedReplacementsCompleted)),
 				)
 			})
 
 			It("updates the ReplacementsCompletedCount field", func() {
-				m.Eventually(nodeRollout, timeout).Should(utils.WithNodeRolloutStatusField("ReplacementsCompletedCount", Equal(len(expectedReplacementsCompleted))))
+				m.Eventually(nodeRollout, timeout).Should(utils.WithField("Status.ReplacementsCompletedCount", Equal(len(expectedReplacementsCompleted))))
 			})
 
 			It("does not cause an error", func() {
@@ -288,12 +288,12 @@ var _ = Describe("NodeRollout Status Suite", func() {
 
 			It("updates the status condition", func() {
 				m.Eventually(nodeRollout, timeout).Should(
-					utils.WithNodeRolloutStatusField("Conditions",
+					utils.WithField("Status.Conditions",
 						ContainElement(SatisfyAll(
-							utils.WithNodeRolloutConditionField("Type", Equal(navarchosv1alpha1.ReplacementsCreatedType)),
-							utils.WithNodeRolloutConditionField("Status", Equal(corev1.ConditionFalse)),
-							utils.WithNodeRolloutConditionField("Reason", Equal(result.ReplacementsCreatedReason)),
-							utils.WithNodeRolloutConditionField("Message", Equal(result.ReplacementsCreatedError.Error())),
+							utils.WithField("Type", Equal(navarchosv1alpha1.ReplacementsCreatedType)),
+							utils.WithField("Status", Equal(corev1.ConditionFalse)),
+							utils.WithField("Reason", Equal(result.ReplacementsCreatedReason)),
+							utils.WithField("Message", Equal(result.ReplacementsCreatedError.Error())),
 						)),
 					),
 				)
@@ -392,12 +392,12 @@ var _ = Describe("NodeRollout Status Suite", func() {
 
 			It("updates the status condition", func() {
 				m.Eventually(nodeRollout, timeout).Should(
-					utils.WithNodeRolloutStatusField("Conditions",
+					utils.WithField("Status.Conditions",
 						ContainElement(SatisfyAll(
-							utils.WithNodeRolloutConditionField("Type", Equal(navarchosv1alpha1.ReplacementsInProgressType)),
-							utils.WithNodeRolloutConditionField("Status", Equal(corev1.ConditionFalse)),
-							utils.WithNodeRolloutConditionField("Reason", Equal(result.ReplacementsInProgressReason)),
-							utils.WithNodeRolloutConditionField("Message", Equal(result.ReplacementsInProgressError.Error())),
+							utils.WithField("Type", Equal(navarchosv1alpha1.ReplacementsInProgressType)),
+							utils.WithField("Status", Equal(corev1.ConditionFalse)),
+							utils.WithField("Reason", Equal(result.ReplacementsInProgressReason)),
+							utils.WithField("Message", Equal(result.ReplacementsInProgressError.Error())),
 						)),
 					),
 				)

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/onsi/gomega"
 	gtypes "github.com/onsi/gomega/types"
-	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -206,101 +204,6 @@ func WithListItems(matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
 			panic(err)
 		}
 		return items
-	}, matcher)
-}
-
-// WithObjectMetaField gets the value of the named field from the Nodes Spec
-func WithObjectMetaField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
-	return gomega.WithTransform(func(obj metav1.Object) interface{} {
-		r := reflect.ValueOf(obj).MethodByName(fmt.Sprintf("Get%s", field))
-		// All Getters take no arguments
-		response := r.Call([]reflect.Value{})
-		// All Getters return 1 argument
-		return response[0].Interface()
-	}, matcher)
-}
-
-// WithNodeSpecField gets the value of the named field from the Nodes Spec
-func WithNodeSpecField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
-	return gomega.WithTransform(func(obj *corev1.Node) interface{} {
-		r := reflect.ValueOf(obj.Spec)
-		f := reflect.Indirect(r).FieldByName(field)
-		return f.Interface()
-	}, matcher)
-}
-
-// WithNodeRolloutSpecField gets the value of the named field from the
-// NodeRollouts Spec
-func WithNodeRolloutSpecField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
-	return gomega.WithTransform(func(obj *navarchosv1alpha1.NodeRollout) interface{} {
-		r := reflect.ValueOf(obj.Spec)
-		f := reflect.Indirect(r).FieldByName(field)
-		return f.Interface()
-	}, matcher)
-}
-
-// WithNodeRolloutStatusField gets the value of the named field from the
-// NodeRollouts Status
-func WithNodeRolloutStatusField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
-	return gomega.WithTransform(func(obj *navarchosv1alpha1.NodeRollout) interface{} {
-		r := reflect.ValueOf(obj.Status)
-		f := reflect.Indirect(r).FieldByName(field)
-		return f.Interface()
-	}, matcher)
-}
-
-// WithNodeRolloutConditionField gets the value of the named field from the
-// NodeRolloutCondition
-func WithNodeRolloutConditionField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
-	return gomega.WithTransform(func(obj navarchosv1alpha1.NodeRolloutCondition) interface{} {
-		r := reflect.ValueOf(obj)
-		f := reflect.Indirect(r).FieldByName(field)
-		return f.Interface()
-	}, matcher)
-}
-
-// WithNodeReplacementSpecField gets the value of the named field from the
-// NodeReplacments Spec
-func WithNodeReplacementSpecField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
-	return WithField(fmt.Sprintf("Spec.%s", field), matcher)
-}
-
-// WithReplacementSpecField gets the value of the named field from the
-// NodeReplacments Spec
-func WithReplacementSpecField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
-	return gomega.WithTransform(func(obj navarchosv1alpha1.ReplacementSpec) interface{} {
-		r := reflect.ValueOf(obj)
-		f := reflect.Indirect(r).FieldByName(field)
-		return f.Interface()
-	}, matcher)
-}
-
-// WithNodeReplacementStatusField gets the value of the named field from the
-// NodeReplacements Status
-func WithNodeReplacementStatusField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
-	return gomega.WithTransform(func(obj *navarchosv1alpha1.NodeReplacement) interface{} {
-		r := reflect.ValueOf(obj.Status)
-		f := reflect.Indirect(r).FieldByName(field)
-		return f.Interface()
-	}, matcher)
-}
-
-// WithNodeReplacementConditionField gets the value of the named field from the
-// NodeReplacementCondition
-func WithNodeReplacementConditionField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
-	return gomega.WithTransform(func(obj navarchosv1alpha1.NodeReplacementCondition) interface{} {
-		r := reflect.ValueOf(obj)
-		f := reflect.Indirect(r).FieldByName(field)
-		return f.Interface()
-	}, matcher)
-}
-
-// WithTaintField gets the value of the named field from the Taint
-func WithTaintField(field string, matcher gtypes.GomegaMatcher) gtypes.GomegaMatcher {
-	return gomega.WithTransform(func(obj *corev1.Taint) interface{} {
-		r := reflect.ValueOf(obj)
-		f := reflect.Indirect(r).FieldByName(field)
-		return f.Interface()
 	}, matcher)
 }
 


### PR DESCRIPTION
Using the more generic `utils.WithField()` matcher is easier to read, and means less code needs to be written. Migrating to it is a sensible thing to do, it lets us remove a number of more complicated matchers.