### PR TITLE
Updates to NodeRollout status

### DIFF
--- a/pkg/controller/nodereplacement/nodereplacement_controller.go
+++ b/pkg/controller/nodereplacement/nodereplacement_controller.go
@@ -19,6 +19,7 @@ package nodereplacement
 import (
 	"context"
 	"fmt"
+	"log"
 
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
 	"github.com/pusher/navarchos/pkg/controller/nodereplacement/handler"
@@ -97,6 +98,12 @@ func (r *ReconcileNodeReplacement) Reconcile(request reconcile.Request) (reconci
 
 	result, err := r.handler.Handle(instance)
 	if err != nil {
+		// Ensure we attempt to update the status even when the handler fails
+		statusErr := status.UpdateStatus(r.Client, instance, result)
+		if statusErr != nil {
+			log.Printf("error updating status: %v", statusErr)
+		}
+
 		return reconcile.Result{}, fmt.Errorf("error handling replacement %s: %v", instance.GetName(), err)
 	}
 	err = status.UpdateStatus(r.Client, instance, result)

--- a/pkg/controller/noderollout/handler/handler_test.go
+++ b/pkg/controller/noderollout/handler/handler_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Handler suite", func() {
 
 			It("does not set any error", func() {
 				Expect(result.ReplacementsCreatedError).To(BeNil())
-				Expect(result.ReplacementsCreatedReason).To(BeEmpty())
+				Expect(result.ReplacementsCreatedReason).To(Equal(navarchosv1alpha1.NodeRolloutConditionReason("CreatedNodeReplacements")))
 			})
 
 			It("should not return an error", func() {
@@ -269,7 +269,7 @@ var _ = Describe("Handler suite", func() {
 
 			It("does not set any error", func() {
 				Expect(result.ReplacementsCreatedError).To(BeNil())
-				Expect(result.ReplacementsCreatedReason).To(BeEmpty())
+				Expect(result.ReplacementsCreatedReason).To(Equal(navarchosv1alpha1.NodeRolloutConditionReason("CreatedNodeReplacements")))
 			})
 
 			It("should not return an error", func() {
@@ -328,7 +328,7 @@ var _ = Describe("Handler suite", func() {
 
 			It("does not set any error", func() {
 				Expect(result.ReplacementsCreatedError).To(BeNil())
-				Expect(result.ReplacementsCreatedReason).To(BeEmpty())
+				Expect(result.ReplacementsCreatedReason).To(Equal(navarchosv1alpha1.NodeRolloutConditionReason("CreatedNodeReplacements")))
 			})
 
 			It("should not return an error", func() {
@@ -499,6 +499,10 @@ var _ = Describe("Handler suite", func() {
 			It("sets the Result Phase field to Completed", func() {
 				completedPhase := navarchosv1alpha1.RolloutPhaseCompleted
 				Expect(result.Phase).To(Equal(&completedPhase))
+			})
+
+			It("sets the ReplacmentsInProgressReason", func() {
+				Expect(result.ReplacementsInProgressReason).To(Equal(navarchosv1alpha1.NodeRolloutConditionReason("ReplacementsCompleted")))
 			})
 		})
 	})

--- a/pkg/controller/noderollout/handler/in_progress.go
+++ b/pkg/controller/noderollout/handler/in_progress.go
@@ -30,6 +30,7 @@ func (h *NodeRolloutHandler) handleInProgress(instance *navarchosv1alpha1.NodeRo
 	result.ReplacementsCompleted = completed
 
 	if len(completed) == len(nodeReplacementList.Items) {
+		result.ReplacementsInProgressReason = "ReplacementsCompleted"
 		completedPhase := navarchosv1alpha1.RolloutPhaseCompleted
 		result.Phase = &completedPhase
 

--- a/pkg/controller/noderollout/handler/new.go
+++ b/pkg/controller/noderollout/handler/new.go
@@ -80,6 +80,7 @@ func (h *NodeRolloutHandler) handleNew(instance *navarchosv1alpha1.NodeRollout) 
 		return result, result.ReplacementsCreatedError
 	}
 
+	result.ReplacementsCreatedReason = "CreatedNodeReplacements"
 	inProgress := navarchosv1alpha1.RolloutPhaseInProgress
 	result.Phase = &inProgress
 

--- a/pkg/controller/noderollout/noderollout_controller.go
+++ b/pkg/controller/noderollout/noderollout_controller.go
@@ -19,6 +19,7 @@ package noderollout
 import (
 	"context"
 	"fmt"
+	"log"
 
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
 	"github.com/pusher/navarchos/pkg/controller/noderollout/handler"
@@ -106,6 +107,12 @@ func (r *ReconcileNodeRollout) Reconcile(request reconcile.Request) (reconcile.R
 
 	result, err := r.handler.Handle(instance)
 	if err != nil {
+		// Ensure we attempt to update the status even when the handler fails
+		statusErr := status.UpdateStatus(r.Client, instance, result)
+		if statusErr != nil {
+			log.Printf("error updating status: %v", statusErr)
+		}
+
 		return reconcile.Result{}, fmt.Errorf("error handling rollout %s: %+v", instance.GetName(), err)
 	}
 	err = status.UpdateStatus(r.Client, instance, result)

--- a/pkg/controller/noderollout/status/status_test.go
+++ b/pkg/controller/noderollout/status/status_test.go
@@ -311,7 +311,7 @@ var _ = Describe("NodeRollout Status Suite", func() {
 				})
 
 				It("causes an error", func() {
-					Expect(updateErr).ToNot(BeNil())
+					Expect(updateErr).To(MatchError("if ReplacementsCreatedError is set, ReplacementsCreatedReason must also be set"))
 				})
 			})
 
@@ -344,9 +344,9 @@ var _ = Describe("NodeRollout Status Suite", func() {
 		})
 
 		Context("when the ReplacementsInProgressError is not set in the Result", func() {
-			Context("and ReplacementsInProgressReason is set", func() {
+			Context("and ReplacementsInProgressReason is set with replacements are still on going", func() {
 				BeforeEach(func() {
-					result.ReplacementsInProgressReason = "ErrorListingNodes"
+					result.ReplacementsInProgressReason = "StillProgressing"
 				})
 
 				It("adds the status condition with Status True", func() {
@@ -355,7 +355,30 @@ var _ = Describe("NodeRollout Status Suite", func() {
 							ContainElement(SatisfyAll(
 								utils.WithField("Type", Equal(navarchosv1alpha1.ReplacementsInProgressType)),
 								utils.WithField("Status", Equal(corev1.ConditionTrue)),
-								utils.WithField("Reason", Equal(navarchosv1alpha1.NodeRolloutConditionReason("ErrorListingNodes"))),
+								utils.WithField("Reason", Equal(navarchosv1alpha1.NodeRolloutConditionReason("StillProgressing"))),
+								utils.WithField("Message", BeEmpty()),
+							)),
+						),
+					)
+				})
+
+				It("does not cause an error", func() {
+					Expect(updateErr).To(BeNil())
+				})
+			})
+
+			Context("and ReplacementsInProgressReason is set with replacements completed", func() {
+				BeforeEach(func() {
+					result.ReplacementsInProgressReason = "ReplacementsCompleted"
+				})
+
+				It("adds the status condition with Status False", func() {
+					m.Eventually(nodeRollout, timeout).Should(
+						utils.WithField("Status.Conditions",
+							ContainElement(SatisfyAll(
+								utils.WithField("Type", Equal(navarchosv1alpha1.ReplacementsInProgressType)),
+								utils.WithField("Status", Equal(corev1.ConditionFalse)),
+								utils.WithField("Reason", Equal(navarchosv1alpha1.NodeRolloutConditionReason("ReplacementsCompleted"))),
 								utils.WithField("Message", BeEmpty()),
 							)),
 						),
@@ -415,7 +438,7 @@ var _ = Describe("NodeRollout Status Suite", func() {
 				})
 
 				It("causes an error", func() {
-					Expect(updateErr).ToNot(BeNil())
+					Expect(updateErr).To(MatchError("if ReplacementsInProgressError is set, ReplacementsInProgressReason must also be set"))
 				})
 			})
 


### PR DESCRIPTION
This ensures that reasons are always set (therefore conditions are always set) and that the InProgress condition doesn't report `True` when the replacements have all completed

This also ensures that status updates occur even when the handler bails for some reason

/CC @pusher/cloud-team 