### PR TITLE
[IS-638] - Implement Handler for New NodeReplacements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -816,6 +816,18 @@
   revision = "db7b694dc208eead64d38030265f702db593fcf2"
 
 [[projects]]
+  digest = "1:2fd38ba4693970d9cf8ebbac0e7bc4d5e54b9d23680d0f2dfb508b04b6f02a13"
+  name = "k8s.io/kubernetes"
+  packages = [
+    "pkg/apis/core",
+    "pkg/apis/core/helper",
+    "pkg/util/taints",
+  ]
+  pruneopts = "T"
+  revision = "a87e9a978f65a8303aa9467537aa59c18122cbf9"
+  version = "v1.14.4"
+
+[[projects]]
   branch = "master"
   digest = "1:75ea823fa8126ea20f2c34040f3f34876a1e52427f5831045da3605d97610b7e"
   name = "k8s.io/utils"
@@ -928,6 +940,7 @@
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/types",
@@ -937,6 +950,7 @@
     "k8s.io/client-go/rest",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",
+    "k8s.io/kubernetes/pkg/util/taints",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
     "sigs.k8s.io/controller-runtime/pkg/controller",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -816,18 +816,6 @@
   revision = "db7b694dc208eead64d38030265f702db593fcf2"
 
 [[projects]]
-  digest = "1:2fd38ba4693970d9cf8ebbac0e7bc4d5e54b9d23680d0f2dfb508b04b6f02a13"
-  name = "k8s.io/kubernetes"
-  packages = [
-    "pkg/apis/core",
-    "pkg/apis/core/helper",
-    "pkg/util/taints",
-  ]
-  pruneopts = "T"
-  revision = "a87e9a978f65a8303aa9467537aa59c18122cbf9"
-  version = "v1.14.4"
-
-[[projects]]
   branch = "master"
   digest = "1:75ea823fa8126ea20f2c34040f3f34876a1e52427f5831045da3605d97610b7e"
   name = "k8s.io/utils"
@@ -950,7 +938,6 @@
     "k8s.io/client-go/rest",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",
-    "k8s.io/kubernetes/pkg/util/taints",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
     "sigs.k8s.io/controller-runtime/pkg/controller",

--- a/pkg/controller/nodereplacement/handler/handler.go
+++ b/pkg/controller/nodereplacement/handler/handler.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"time"
 
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
@@ -44,13 +43,14 @@ func NewNodeReplacementHandler(c client.Client, opts *Options) *NodeReplacementH
 // instance of a NodeReplacement can be handled in full without interruption
 func (h *NodeReplacementHandler) Handle(instance *navarchosv1alpha1.NodeReplacement) (*status.Result, error) {
 	var result *status.Result
+	var err error
 
 	switch instance.Status.Phase {
 	default:
 		instance.Status.Phase = navarchosv1alpha1.ReplacementPhaseNew
 		fallthrough // this is important, we want one instance to be handled to completion without a requeue if possible
 	case navarchosv1alpha1.ReplacementPhaseNew:
-		result, err := h.handleNew(instance)
+		result, err = h.handleNew(instance)
 		if err != nil {
 			return result, err
 		}
@@ -59,7 +59,7 @@ func (h *NodeReplacementHandler) Handle(instance *navarchosv1alpha1.NodeReplacem
 		}
 		fallthrough // this is important, we want one instance to be handled to completion without a requeue if possible
 	case navarchosv1alpha1.ReplacementPhaseInProgress:
-		result, err := h.handleInProgress(instance, result)
+		result, err = h.handleInProgress(instance, result)
 		if err != nil {
 			return result, err
 		}
@@ -68,10 +68,6 @@ func (h *NodeReplacementHandler) Handle(instance *navarchosv1alpha1.NodeReplacem
 	return result, nil
 }
 
-func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeReplacement) (*status.Result, error) {
-	return &status.Result{}, fmt.Errorf("method not implemented")
-}
-
 func (h *NodeReplacementHandler) handleInProgress(instance *navarchosv1alpha1.NodeReplacement, result *status.Result) (*status.Result, error) {
-	return &status.Result{}, fmt.Errorf("method not implemented")
+	return result, nil
 }

--- a/pkg/controller/nodereplacement/handler/handler.go
+++ b/pkg/controller/nodereplacement/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"time"
 
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
@@ -47,8 +48,19 @@ func (h *NodeReplacementHandler) Handle(instance *navarchosv1alpha1.NodeReplacem
 
 	switch instance.Status.Phase {
 	default:
-		instance.Status.Phase = navarchosv1alpha1.ReplacementPhaseNew
-		fallthrough // this is important, we want one instance to be handled to completion without a requeue if possible
+		newPhase := navarchosv1alpha1.ReplacementPhaseNew
+		// Update status before starting next phase
+		err = status.UpdateStatus(h.client, instance, &status.Result{
+			Phase: &newPhase,
+		})
+		if err != nil {
+			// This is an API error which means other errors are also likely,
+			// bail and requeue We will reattempt the status update anyway where
+			// this is called
+			return result, fmt.Errorf("error updating status: %v", err)
+		}
+
+		fallthrough // This is important, we want one instance to be handled to completion without a requeue if possible
 	case navarchosv1alpha1.ReplacementPhaseNew:
 		result, err = h.handleNew(instance)
 		if err != nil {
@@ -57,14 +69,24 @@ func (h *NodeReplacementHandler) Handle(instance *navarchosv1alpha1.NodeReplacem
 		if result.Requeue {
 			return result, nil
 		}
-		fallthrough // this is important, we want one instance to be handled to completion without a requeue if possible
+
+		// Update status before starting next phase
+		err = status.UpdateStatus(h.client, instance, result)
+		if err != nil {
+			// This is an API error which means other error are also likely,
+			// bail and requeue We will reattempt the status update anyway where
+			// this is called
+			return result, fmt.Errorf("error updating status: %v", err)
+		}
+
+		fallthrough // This is important, we want one instance to be handled to completion without a requeue if possible
 	case navarchosv1alpha1.ReplacementPhaseInProgress:
 		result, err = h.handleInProgress(instance, result)
 		if err != nil {
 			return result, err
 		}
 	}
-
+	// Nothing left to do
 	return result, nil
 }
 

--- a/pkg/controller/nodereplacement/handler/handler.go
+++ b/pkg/controller/nodereplacement/handler/handler.go
@@ -40,7 +40,38 @@ func NewNodeReplacementHandler(c client.Client, opts *Options) *NodeReplacementH
 }
 
 // Handle performs the business logic of a NodeReplacement and returns
-// information in a Result
+// information in a Result. The use of fallthrough is to ensure that one
+// instance of a NodeReplacement can be handled in full without interruption
 func (h *NodeReplacementHandler) Handle(instance *navarchosv1alpha1.NodeReplacement) (*status.Result, error) {
+	var result *status.Result
+
+	switch instance.Status.Phase {
+	default:
+		instance.Status.Phase = navarchosv1alpha1.ReplacementPhaseNew
+		fallthrough // this is important, we want one instance to be handled to completion without a requeue if possible
+	case navarchosv1alpha1.ReplacementPhaseNew:
+		result, err := h.handleNew(instance)
+		if err != nil {
+			return result, err
+		}
+		if result.Requeue {
+			return result, nil
+		}
+		fallthrough // this is important, we want one instance to be handled to completion without a requeue if possible
+	case navarchosv1alpha1.ReplacementPhaseInProgress:
+		result, err := h.handleInProgress(instance, result)
+		if err != nil {
+			return result, err
+		}
+	}
+
+	return result, nil
+}
+
+func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeReplacement) (*status.Result, error) {
+	return &status.Result{}, fmt.Errorf("method not implemented")
+}
+
+func (h *NodeReplacementHandler) handleInProgress(instance *navarchosv1alpha1.NodeReplacement, result *status.Result) (*status.Result, error) {
 	return &status.Result{}, fmt.Errorf("method not implemented")
 }

--- a/pkg/controller/nodereplacement/handler/handler_test.go
+++ b/pkg/controller/nodereplacement/handler/handler_test.go
@@ -25,6 +25,7 @@ import (
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
 	"github.com/pusher/navarchos/pkg/controller/nodereplacement/status"
 	"github.com/pusher/navarchos/test/utils"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,6 +127,7 @@ var _ = Describe("Handler suite", func() {
 			&navarchosv1alpha1.NodeReplacementList{},
 			&corev1.NodeList{},
 			&corev1.PodList{},
+			&appsv1.DaemonSetList{},
 			&policyv1beta1.PodDisruptionBudgetList{},
 		)
 
@@ -137,6 +139,14 @@ var _ = Describe("Handler suite", func() {
 	})
 
 	Context("when the Handler is called on a New NodeReplacement", func() {
+		BeforeEach(func() {
+			m.Update(nodeReplacement, func(obj utils.Object) utils.Object {
+				nr, _ := obj.(*navarchosv1alpha1.NodeReplacement)
+				nr.Spec.NodeUID = workerNode1.GetUID()
+				nr.Spec.NodeName = workerNode1.GetName()
+				return nr
+			}, timeout).Should(Succeed())
+		})
 		JustBeforeEach(func() {
 			result, handleErr = h.Handle(nodeReplacement)
 		})
@@ -157,7 +167,7 @@ var _ = Describe("Handler suite", func() {
 				Expect(*highPriorityNR.Spec.ReplacementSpec.Priority).To(BeNumerically(">", *nodeReplacement.Spec.ReplacementSpec.Priority))
 			})
 
-			PIt("requeues the NodeReplacement", func() {
+			It("requeues the NodeReplacement", func() {
 				Expect(result.Requeue).To(BeTrue())
 				Expect(result.RequeueReason).To(Equal("NodeReplacement \"high-priority\" has a higher priority"))
 			})
@@ -166,7 +176,7 @@ var _ = Describe("Handler suite", func() {
 				Expect(result.NodePods).To(BeEmpty())
 			})
 
-			PIt("should not return an error", func() {
+			It("should not return an error", func() {
 				Expect(handleErr).ToNot(HaveOccurred())
 			})
 		})
@@ -192,7 +202,7 @@ var _ = Describe("Handler suite", func() {
 				Expect(result.RequeueReason).To(BeEmpty())
 			})
 
-			PIt("sets the Result NodePods field to contain a list of pods on the node", func() {
+			It("sets the Result NodePods field to contain a list of pods on the node", func() {
 				Expect(result.NodePods).To(ConsistOf(
 					"pod-1",
 					"pod-2",
@@ -200,11 +210,12 @@ var _ = Describe("Handler suite", func() {
 				))
 			})
 
-			PIt("sets the Result Phase field to InProgress", func() {
-				Expect(result.Phase).To(Equal(navarchosv1alpha1.ReplacementPhaseInProgress))
+			It("sets the Result Phase field to InProgress", func() {
+				inProgress := navarchosv1alpha1.ReplacementPhaseInProgress
+				Expect(result.Phase).To(Equal(&inProgress))
 			})
 
-			PIt("should not return an error", func() {
+			It("should not return an error", func() {
 				Expect(handleErr).ToNot(HaveOccurred())
 			})
 		})
@@ -218,7 +229,7 @@ var _ = Describe("Handler suite", func() {
 				m.Create(highPriorityNR).Should(Succeed())
 			})
 
-			PIt("requeues the NodeReplacement", func() {
+			It("requeues the NodeReplacement", func() {
 				Expect(result.Requeue).To(BeTrue())
 				Expect(result.RequeueReason).To(Equal("NodeReplacement \"in-progress\" is already in-progress"))
 			})
@@ -227,22 +238,22 @@ var _ = Describe("Handler suite", func() {
 				Expect(result.NodePods).To(BeEmpty())
 			})
 
-			PIt("should not return an error", func() {
+			It("should not return an error", func() {
 				Expect(handleErr).ToNot(HaveOccurred())
 			})
 		})
 
-		PIt("should cordon the node", func() {
+		It("should cordon the node", func() {
 			m.Eventually(workerNode1, timeout).Should(utils.WithField("Spec.Unschedulable", BeTrue()))
 			m.Eventually(workerNode1, timeout).Should(utils.WithField("Spec.Taints",
 				ContainElement(SatisfyAll(
-					utils.WithField("Effect", Equal("NoSchedule")),
+					utils.WithField("Effect", Equal(corev1.TaintEffect("NoSchedule"))),
 					utils.WithField("Key", Equal("node.kubernetes.io/unschedulable")),
 				)),
 			))
 		})
 
-		PIt("should list all Pods in the Result NodePods field", func() {
+		It("should list all Pods in the Result NodePods field", func() {
 			Expect(result.NodePods).To(ConsistOf(
 				"pod-1",
 				"pod-2",
@@ -260,7 +271,7 @@ var _ = Describe("Handler suite", func() {
 			}
 		})
 
-		PIt("should not return an error", func() {
+		It("should not return an error", func() {
 			Expect(handleErr).ToNot(HaveOccurred())
 		})
 
@@ -275,19 +286,19 @@ var _ = Describe("Handler suite", func() {
 				}, timeout).Should(Succeed())
 			})
 
-			PIt("should ignore the DaemonSet managed Pod", func() {
+			It("should ignore the DaemonSet managed Pod", func() {
 				Expect(result.IgnoredPods).To(ConsistOf(
 					navarchosv1alpha1.PodReason{Name: "pod-1", Reason: "pod owned by a DaemonSet"},
 				))
 			})
 
-			PIt("should not return an error", func() {
+			It("should not return an error", func() {
 				Expect(handleErr).ToNot(HaveOccurred())
 			})
 		})
 	})
 
-	Context("when the Handler is called on an InProgress NodeReplacement", func() {
+	PContext("when the Handler is called on an InProgress NodeReplacement", func() {
 		BeforeEach(func() {
 			// Set the NodeReplacement as we expect it to be at this point
 			m.Update(nodeReplacement, func(obj utils.Object) utils.Object {

--- a/pkg/controller/nodereplacement/handler/handler_test.go
+++ b/pkg/controller/nodereplacement/handler/handler_test.go
@@ -110,6 +110,8 @@ var _ = Describe("Handler suite", func() {
 
 		nodeReplacement = utils.ExampleNodeReplacement.DeepCopy()
 		nodeReplacement.SetOwnerReferences([]metav1.OwnerReference{utils.GetOwnerReferenceForNode(workerNode1)})
+		nodeReplacement.Spec.NodeUID = workerNode1.GetUID()
+		nodeReplacement.Spec.NodeName = workerNode1.GetName()
 		m.Create(nodeReplacement).Should(Succeed())
 	})
 
@@ -139,14 +141,6 @@ var _ = Describe("Handler suite", func() {
 	})
 
 	Context("when the Handler is called on a New NodeReplacement", func() {
-		BeforeEach(func() {
-			m.Update(nodeReplacement, func(obj utils.Object) utils.Object {
-				nr, _ := obj.(*navarchosv1alpha1.NodeReplacement)
-				nr.Spec.NodeUID = workerNode1.GetUID()
-				nr.Spec.NodeName = workerNode1.GetName()
-				return nr
-			}, timeout).Should(Succeed())
-		})
 		JustBeforeEach(func() {
 			result, handleErr = h.Handle(nodeReplacement)
 		})

--- a/pkg/controller/nodereplacement/handler/handler_test.go
+++ b/pkg/controller/nodereplacement/handler/handler_test.go
@@ -196,17 +196,21 @@ var _ = Describe("Handler suite", func() {
 				Expect(result.RequeueReason).To(BeEmpty())
 			})
 
-			It("sets the Result NodePods field to contain a list of pods on the node", func() {
-				Expect(result.NodePods).To(ConsistOf(
-					"pod-1",
-					"pod-2",
-					"pod-3",
+			It("sets the Status NodePods field to contain a list of pods to evict", func() {
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.NodePods",
+					ConsistOf(
+						"pod-1",
+						"pod-2",
+						"pod-3",
+					),
 				))
 			})
 
-			It("sets the Result Phase field to InProgress", func() {
+			It("sets the Status Phase field to InProgress", func() {
 				inProgress := navarchosv1alpha1.ReplacementPhaseInProgress
-				Expect(result.Phase).To(Equal(&inProgress))
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.Phase",
+					Equal(inProgress),
+				))
 			})
 
 			It("should not return an error", func() {
@@ -247,11 +251,13 @@ var _ = Describe("Handler suite", func() {
 			))
 		})
 
-		It("should list all Pods in the Result NodePods field", func() {
-			Expect(result.NodePods).To(ConsistOf(
-				"pod-1",
-				"pod-2",
-				"pod-3",
+		It("should list all Pods in the Status NodePods field", func() {
+			m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.NodePods",
+				ConsistOf(
+					"pod-1",
+					"pod-2",
+					"pod-3",
+				),
 			))
 		})
 
@@ -281,8 +287,10 @@ var _ = Describe("Handler suite", func() {
 			})
 
 			It("should ignore the DaemonSet managed Pod", func() {
-				Expect(result.IgnoredPods).To(ConsistOf(
-					navarchosv1alpha1.PodReason{Name: "pod-1", Reason: "pod owned by a DaemonSet"},
+				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.IgnoredPods",
+					ConsistOf(
+						navarchosv1alpha1.PodReason{Name: "pod-1", Reason: "pod owned by a DaemonSet"},
+					),
 				))
 			})
 
@@ -292,7 +300,7 @@ var _ = Describe("Handler suite", func() {
 		})
 	})
 
-	PContext("when the Handler is called on an InProgress NodeReplacement", func() {
+	Context("when the Handler is called on an InProgress NodeReplacement", func() {
 		BeforeEach(func() {
 			// Set the NodeReplacement as we expect it to be at this point
 			m.Update(nodeReplacement, func(obj utils.Object) utils.Object {

--- a/pkg/controller/nodereplacement/handler/new.go
+++ b/pkg/controller/nodereplacement/handler/new.go
@@ -14,19 +14,12 @@ import (
 
 // handleNew handles a NodeReplacement in the New phase
 func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeReplacement) (*status.Result, error) {
-	result := &status.Result{}
-
-	replacements := &navarchosv1alpha1.NodeReplacementList{}
-	err := h.client.List(context.Background(), replacements)
-	if err != nil {
-		return &status.Result{}, err
-	}
-
-	proceed, reason := shouldProcess(instance, replacements)
+	proceed, reason := h.shouldRequeueReplacement(instance)
 	if !proceed {
-		result.Requeue = true
-		result.RequeueReason = reason
-		return result, nil
+		return &status.Result{
+			Requeue:       true,
+			RequeueReason: reason,
+		}, nil
 	}
 
 	node, exists, err := h.getNode(instance)
@@ -37,10 +30,10 @@ func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeRepla
 		completedPhase := navarchosv1alpha1.ReplacementPhaseCompleted
 		completedTime := metav1.Now()
 
-		result.Phase = &completedPhase
-		result.CompletionTimestamp = &completedTime
-
-		return result, nil
+		return &status.Result{
+			Phase:               &completedPhase,
+			CompletionTimestamp: &completedTime,
+		}, nil
 	}
 
 	err = h.cordonNode(node)
@@ -48,10 +41,10 @@ func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeRepla
 		return &status.Result{}, fmt.Errorf("error cordoning node: %v", err)
 	}
 
-	result = &status.Result{}
+	result := &status.Result{}
 	result.NodePods, result.IgnoredPods, err = h.processPods(node)
 	if err != nil {
-		return &status.Result{}, fmt.Errorf("error listing pods on node %s: %v", node.GetName(), err)
+		return result, fmt.Errorf("error listing pods on node %s: %v", node.GetName(), err)
 	}
 
 	inProgress := navarchosv1alpha1.ReplacementPhaseInProgress
@@ -60,10 +53,16 @@ func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeRepla
 	return result, nil
 }
 
-// shouldProcess determines if a replacement should be processed. If the
+// shouldRequeueReplacement determines if a replacement should be processed. If the
 // replacement passed should be processed it returns true along with an empty
 // reason string, otherwise it returns false with a reason
-func shouldProcess(instance *navarchosv1alpha1.NodeReplacement, replacements *navarchosv1alpha1.NodeReplacementList) (bool, string) {
+func (h *NodeReplacementHandler) shouldRequeueReplacement(instance *navarchosv1alpha1.NodeReplacement) (bool, string) {
+	replacements := &navarchosv1alpha1.NodeReplacementList{}
+	err := h.client.List(context.Background(), replacements)
+	if err != nil {
+		return false, fmt.Sprintf("failed to list NodeReplacements: %v", err)
+	}
+
 	for _, replacement := range replacements.Items {
 		if *replacement.Spec.ReplacementSpec.Priority > *instance.Spec.ReplacementSpec.Priority {
 			reason := fmt.Sprintf("NodeReplacement \"%s\" has a higher priority", replacement.GetName())

--- a/pkg/controller/nodereplacement/handler/new.go
+++ b/pkg/controller/nodereplacement/handler/new.go
@@ -1,0 +1,107 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
+	"github.com/pusher/navarchos/pkg/controller/nodereplacement/status"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/util/taints"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// handleNew handles a NodeReplacement in the New phase
+func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeReplacement) (*status.Result, error) {
+	result := &status.Result{}
+	replacements := &navarchosv1alpha1.NodeReplacementList{}
+	err := h.client.List(context.Background(), replacements)
+	if err != nil {
+		return &status.Result{}, err
+	}
+
+	for _, replacement := range replacements.Items {
+		if *replacement.Spec.ReplacementSpec.Priority > *instance.Spec.ReplacementSpec.Priority {
+			result.Requeue = true
+			result.RequeueReason = fmt.Sprintf("NodeReplacement \"%s\" has a higher priority", replacement.GetName())
+			return result, nil
+		}
+		if replacement.Status.Phase == navarchosv1alpha1.ReplacementPhaseInProgress {
+			result.Requeue = true
+			result.RequeueReason = fmt.Sprintf("NodeReplacement \"%s\" is already in-progress", replacement.GetName())
+			return result, nil
+		}
+	}
+
+	node := &corev1.Node{}
+
+	err = h.client.Get(context.Background(), client.ObjectKey{
+		Name: instance.Spec.NodeName,
+	}, node)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// node no longer exists, mark as completed
+			completedPhase := navarchosv1alpha1.ReplacementPhaseCompleted
+			completedTime := metav1.Now()
+
+			result.Phase = &completedPhase
+			result.CompletionTimestamp = &completedTime
+
+			return result, nil
+		}
+
+		return &status.Result{}, err
+	}
+
+	if node.GetUID() != instance.Spec.NodeUID {
+		// node no longer exists, mark as completed
+		completedPhase := navarchosv1alpha1.ReplacementPhaseCompleted
+		completedTime := metav1.Now()
+
+		result.Phase = &completedPhase
+		result.CompletionTimestamp = &completedTime
+
+		return result, nil
+	}
+
+	// cordon the node
+	node.Spec.Unschedulable = true
+	node, _, err = taints.AddOrUpdateTaint(node, &corev1.Taint{
+		Key:    "node.kubernetes.io/unschedulable",
+		Effect: corev1.TaintEffect("NoSchedule"),
+	})
+	err = h.client.Update(context.Background(), node)
+	if err != nil {
+		return &status.Result{}, err
+	}
+
+	podList := &corev1.PodList{}
+	err = h.client.List(context.Background(), podList, client.MatchingField("spec.nodeName", node.GetName()))
+	if err != nil {
+		return &status.Result{}, err
+	}
+
+	nodePods := []string{}
+	ignoredPods := []navarchosv1alpha1.PodReason{}
+	for _, pod := range podList.Items {
+
+		ownerRefs := pod.GetOwnerReferences()
+		for _, ref := range ownerRefs {
+			if ref.Kind == "DaemonSet" {
+				ignoredPods = append(ignoredPods, navarchosv1alpha1.PodReason{Name: pod.GetName(), Reason: "pod owned by a DaemonSet"})
+			}
+		}
+
+		nodePods = append(nodePods, pod.GetName())
+	}
+
+	result.NodePods = nodePods
+	result.IgnoredPods = ignoredPods
+
+	inProgress := navarchosv1alpha1.ReplacementPhaseInProgress
+	result.Phase = &inProgress
+
+	return result, nil
+}

--- a/pkg/controller/nodereplacement/handler/new.go
+++ b/pkg/controller/nodereplacement/handler/new.go
@@ -16,47 +16,25 @@ import (
 // handleNew handles a NodeReplacement in the New phase
 func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeReplacement) (*status.Result, error) {
 	result := &status.Result{}
+
 	replacements := &navarchosv1alpha1.NodeReplacementList{}
 	err := h.client.List(context.Background(), replacements)
 	if err != nil {
 		return &status.Result{}, err
 	}
 
-	for _, replacement := range replacements.Items {
-		if *replacement.Spec.ReplacementSpec.Priority > *instance.Spec.ReplacementSpec.Priority {
-			result.Requeue = true
-			result.RequeueReason = fmt.Sprintf("NodeReplacement \"%s\" has a higher priority", replacement.GetName())
-			return result, nil
-		}
-		if replacement.Status.Phase == navarchosv1alpha1.ReplacementPhaseInProgress {
-			result.Requeue = true
-			result.RequeueReason = fmt.Sprintf("NodeReplacement \"%s\" is already in-progress", replacement.GetName())
-			return result, nil
-		}
+	proceed, reason := shouldProcess(instance, replacements)
+	if !proceed {
+		result.Requeue = true
+		result.RequeueReason = reason
+		return result, nil
 	}
 
-	node := &corev1.Node{}
-
-	err = h.client.Get(context.Background(), client.ObjectKey{
-		Name: instance.Spec.NodeName,
-	}, node)
+	node, exists, err := h.getNode(instance)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// node no longer exists, mark as completed
-			completedPhase := navarchosv1alpha1.ReplacementPhaseCompleted
-			completedTime := metav1.Now()
-
-			result.Phase = &completedPhase
-			result.CompletionTimestamp = &completedTime
-
-			return result, nil
-		}
-
-		return &status.Result{}, err
+		return &status.Result{}, fmt.Errorf("error getting node: %v", err)
 	}
-
-	if node.GetUID() != instance.Spec.NodeUID {
-		// node no longer exists, mark as completed
+	if !exists {
 		completedPhase := navarchosv1alpha1.ReplacementPhaseCompleted
 		completedTime := metav1.Now()
 
@@ -66,42 +44,103 @@ func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeRepla
 		return result, nil
 	}
 
-	// cordon the node
-	node.Spec.Unschedulable = true
-	node, _, err = taints.AddOrUpdateTaint(node, &corev1.Taint{
-		Key:    "node.kubernetes.io/unschedulable",
-		Effect: corev1.TaintEffect("NoSchedule"),
-	})
-	err = h.client.Update(context.Background(), node)
+	err = h.cordonNode(node)
 	if err != nil {
-		return &status.Result{}, err
+		return &status.Result{}, fmt.Errorf("error cordoning node: %v", err)
 	}
 
-	podList := &corev1.PodList{}
-	err = h.client.List(context.Background(), podList, client.MatchingField("spec.nodeName", node.GetName()))
+	result = &status.Result{}
+	result.NodePods, result.IgnoredPods, err = h.processPods(node)
 	if err != nil {
-		return &status.Result{}, err
+		return &status.Result{}, fmt.Errorf("error listing pods on node %s: %v", node.GetName(), err)
 	}
-
-	nodePods := []string{}
-	ignoredPods := []navarchosv1alpha1.PodReason{}
-	for _, pod := range podList.Items {
-
-		ownerRefs := pod.GetOwnerReferences()
-		for _, ref := range ownerRefs {
-			if ref.Kind == "DaemonSet" {
-				ignoredPods = append(ignoredPods, navarchosv1alpha1.PodReason{Name: pod.GetName(), Reason: "pod owned by a DaemonSet"})
-			}
-		}
-
-		nodePods = append(nodePods, pod.GetName())
-	}
-
-	result.NodePods = nodePods
-	result.IgnoredPods = ignoredPods
 
 	inProgress := navarchosv1alpha1.ReplacementPhaseInProgress
 	result.Phase = &inProgress
 
 	return result, nil
+}
+
+// shouldProcess determines if a replacement should be processed. If the
+// replacement passed should be processed it returns true along with an empty
+// reason string, otherwise it returns false with a reason
+func shouldProcess(instance *navarchosv1alpha1.NodeReplacement, replacements *navarchosv1alpha1.NodeReplacementList) (bool, string) {
+	for _, replacement := range replacements.Items {
+		if *replacement.Spec.ReplacementSpec.Priority > *instance.Spec.ReplacementSpec.Priority {
+			reason := fmt.Sprintf("NodeReplacement \"%s\" has a higher priority", replacement.GetName())
+			return false, reason
+		}
+		if replacement.Status.Phase == navarchosv1alpha1.ReplacementPhaseInProgress {
+			reason := fmt.Sprintf("NodeReplacement \"%s\" is already in-progress", replacement.GetName())
+			return false, reason
+		}
+	}
+
+	return true, ""
+}
+
+// cordonNode cordons a node
+func (h *NodeReplacementHandler) cordonNode(node *corev1.Node) error {
+	node.Spec.Unschedulable = true
+	node, _, err := taints.AddOrUpdateTaint(node, &corev1.Taint{
+		Key:    "node.kubernetes.io/unschedulable",
+		Effect: corev1.TaintEffect("NoSchedule"),
+	})
+	if err != nil {
+		return err
+	}
+
+	err = h.client.Update(context.Background(), node)
+
+	return err
+}
+
+// processPods processes the pods present on a node. It returns a []string
+// consisting of all pods on the node and a []PodReason consisitng of all pods
+// that are ignored
+func (h *NodeReplacementHandler) processPods(node *corev1.Node) ([]string, []navarchosv1alpha1.PodReason, error) {
+	podList := &corev1.PodList{}
+	err := h.client.List(context.Background(), podList, client.MatchingField("spec.nodeName", node.GetName()))
+	if err != nil {
+		return []string{}, []navarchosv1alpha1.PodReason{}, err
+	}
+
+	nodePods := []string{}
+	ignoredPods := []navarchosv1alpha1.PodReason{}
+	for _, pod := range podList.Items {
+		ownerRefs := pod.GetOwnerReferences()
+
+		for _, ref := range ownerRefs {
+			if ref.Kind == "DaemonSet" {
+				ignoredPods = append(ignoredPods, navarchosv1alpha1.PodReason{Name: pod.GetName(), Reason: "pod owned by a DaemonSet"})
+			}
+		}
+		nodePods = append(nodePods, pod.GetName())
+	}
+
+	return nodePods, ignoredPods, nil
+}
+
+// getNode gets the node specified in a NodeReplacement. If it does not exist it
+// returns false, otherwise it returns the node and a true bool
+func (h *NodeReplacementHandler) getNode(instance *navarchosv1alpha1.NodeReplacement) (*corev1.Node, bool, error) {
+	node := &corev1.Node{}
+	err := h.client.Get(context.Background(), client.ObjectKey{
+		Name: instance.Spec.NodeName,
+	}, node)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, false, nil
+		}
+
+		return nil, false, err
+	}
+
+	// if  the node UID has changed, it has already been replaced
+	if node.GetUID() != instance.Spec.NodeUID {
+		return nil, false, nil
+	}
+
+	return node, true, nil
 }

--- a/pkg/controller/nodereplacement/handler/new_test.go
+++ b/pkg/controller/nodereplacement/handler/new_test.go
@@ -1,0 +1,1 @@
+package handler

--- a/pkg/controller/nodereplacement/handler/new_test.go
+++ b/pkg/controller/nodereplacement/handler/new_test.go
@@ -1,1 +1,372 @@
 package handler
+
+import (
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
+	"github.com/pusher/navarchos/test/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/util/taints"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ = Describe("new node replacement handler", func() {
+	var m utils.Matcher
+	var h *NodeReplacementHandler
+	var opts *Options
+
+	var nodeReplacement *navarchosv1alpha1.NodeReplacement
+	var highPriorityNR *navarchosv1alpha1.NodeReplacement
+	var inProgressNR *navarchosv1alpha1.NodeReplacement
+	var mgrStopped *sync.WaitGroup
+	var stopMgr chan struct{}
+
+	var workerNode1 *corev1.Node
+	var workerNode2 *corev1.Node
+	var pod1 *corev1.Pod
+	var pod2 *corev1.Pod
+	var pod3 *corev1.Pod
+	var pod4 *corev1.Pod
+
+	const timeout = time.Second * 5
+	const consistentlyTimeout = time.Second
+
+	var newPod = func(name string, node *corev1.Node) *corev1.Pod {
+		pod := utils.ExamplePod.DeepCopy()
+		pod.Name = name
+		pod.Spec.NodeName = node.Name
+		return pod
+	}
+
+	var setPodRunning = func(obj utils.Object) utils.Object {
+		pod, _ := obj.(*corev1.Pod)
+		pod.Status.Phase = corev1.PodRunning
+		return pod
+	}
+
+	var setPodSucceeded = func(obj utils.Object) utils.Object {
+		pod, _ := obj.(*corev1.Pod)
+		pod.Status.Phase = corev1.PodSucceeded
+		return pod
+	}
+
+	BeforeEach(func() {
+		mgr, err := manager.New(cfg, manager.Options{})
+		Expect(err).NotTo(HaveOccurred())
+		c, err := client.New(cfg, client.Options{})
+		Expect(err).ToNot(HaveOccurred())
+		m = utils.Matcher{Client: c}
+
+		stopMgr, mgrStopped = StartTestManager(mgr)
+
+		grace := 5 * time.Second
+		opts = &Options{
+			EvictionGracePeriod: &grace,
+		}
+
+		// Create a node to act as owners for the NodeReplacements created
+		workerNode1 = utils.ExampleNodeWorker1.DeepCopy()
+		workerNode2 = utils.ExampleNodeWorker2.DeepCopy()
+		m.Create(workerNode1).Should(Succeed())
+		m.Create(workerNode2).Should(Succeed())
+
+		// Create some pods attached to the nodes
+		pod1 = newPod("pod-1", workerNode1)
+		pod2 = newPod("pod-2", workerNode1)
+		pod3 = newPod("pod-3", workerNode1)
+		pod4 = newPod("pod-4", workerNode2)
+		m.Create(pod1).Should(Succeed())
+		m.Create(pod2).Should(Succeed())
+		m.Create(pod3).Should(Succeed())
+		m.Create(pod4).Should(Succeed())
+		m.UpdateStatus(pod1, setPodRunning, timeout).Should(Succeed())
+		m.UpdateStatus(pod2, setPodRunning, timeout).Should(Succeed())
+		m.UpdateStatus(pod3, setPodRunning, timeout).Should(Succeed())
+		m.UpdateStatus(pod4, setPodRunning, timeout).Should(Succeed())
+
+		nodeReplacement = utils.ExampleNodeReplacement.DeepCopy()
+		nodeReplacement.SetOwnerReferences([]metav1.OwnerReference{utils.GetOwnerReferenceForNode(workerNode1)})
+		m.Create(nodeReplacement).Should(Succeed())
+
+		highPriorityNR = utils.ExampleNodeReplacement.DeepCopy()
+		inProgressNR = utils.ExampleNodeReplacement.DeepCopy()
+
+		highPriorityNR.Spec.ReplacementSpec.Priority = intPtr(10)
+		highPriorityNR.SetName("high-priority")
+
+		inProgressNR.Status.Phase = navarchosv1alpha1.ReplacementPhaseInProgress
+		inProgressNR.SetName("in-progress")
+
+		m.Create(highPriorityNR).Should(Succeed())
+		m.Create(inProgressNR).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+
+		pods := &corev1.PodList{}
+		m.List(pods).Should(Succeed())
+		for _, pod := range pods.Items {
+			m.UpdateStatus(&pod, setPodSucceeded, timeout).Should(Succeed())
+		}
+
+		utils.DeleteAll(cfg, timeout,
+			&navarchosv1alpha1.NodeReplacementList{},
+			&corev1.NodeList{},
+			&corev1.PodList{},
+			&appsv1.DaemonSetList{},
+			&policyv1beta1.PodDisruptionBudgetList{},
+		)
+
+		m.Eventually(&corev1.PodList{}, timeout).Should(utils.WithListItems(BeEmpty()))
+	})
+
+	JustBeforeEach(func() {
+		h = NewNodeReplacementHandler(m.Client, opts)
+	})
+
+	Context("shouldProcess", func() {
+		var proceed bool
+		var reason string
+		var replacements *navarchosv1alpha1.NodeReplacementList
+
+		JustBeforeEach(func() {
+			proceed, reason = shouldProcess(nodeReplacement, replacements)
+		})
+		Context("if a another NodeReplacement is higher priority", func() {
+			BeforeEach(func() {
+				m.Update(nodeReplacement, func(obj utils.Object) utils.Object {
+					nr, _ := obj.(*navarchosv1alpha1.NodeReplacement)
+					nr.Spec.ReplacementSpec.Priority = intPtr(0)
+					return nr
+				}, timeout).Should(Succeed())
+
+				replacements = &navarchosv1alpha1.NodeReplacementList{
+					Items: []navarchosv1alpha1.NodeReplacement{
+						*nodeReplacement, *highPriorityNR,
+					},
+				}
+			})
+
+			It("sets proceed to false", func() {
+				Expect(proceed).To(BeFalse())
+			})
+
+			It("requeues the NodeReplacement in the result", func() {
+				Expect(reason).To(Equal("NodeReplacement \"high-priority\" has a higher priority"))
+			})
+		})
+
+		Context("if a another NodeReplacement is in Phase InProgress", func() {
+			BeforeEach(func() {
+				replacements = &navarchosv1alpha1.NodeReplacementList{
+					Items: []navarchosv1alpha1.NodeReplacement{
+						*nodeReplacement, *inProgressNR,
+					},
+				}
+			})
+
+			It("sets proceed to false", func() {
+				Expect(proceed).To(BeFalse())
+			})
+
+			It("requeues the NodeReplacement", func() {
+				Expect(reason).To(Equal("NodeReplacement \"in-progress\" is already in-progress"))
+			})
+		})
+
+		Context("if the NodeReplacement should proceed", func() {
+			BeforeEach(func() {
+				replacements = &navarchosv1alpha1.NodeReplacementList{
+					Items: []navarchosv1alpha1.NodeReplacement{
+						*nodeReplacement,
+					},
+				}
+			})
+
+			It("sets proceed to true", func() {
+				Expect(proceed).To(BeTrue())
+			})
+
+			It("does not set the reason string", func() {
+				Expect(reason).To(Equal(""))
+			})
+		})
+	})
+
+	Context("getNode", func() {
+		var node *corev1.Node
+		var exists bool
+		var existsErr error
+
+		JustBeforeEach(func() {
+			node, exists, existsErr = h.getNode(nodeReplacement)
+		})
+
+		Context("when there is an error thrown", func() {
+			Context("and the reason for the error is 'NotFound'", func() {
+				BeforeEach(func() {
+					m.Update(nodeReplacement, func(obj utils.Object) utils.Object {
+						nr, _ := obj.(*navarchosv1alpha1.NodeReplacement)
+						nr.Spec.NodeName = "does-not-exist"
+						return nr
+					}, timeout).Should(Succeed())
+				})
+
+				It("sets exists to false", func() {
+					Expect(exists).To(BeFalse())
+				})
+
+				It("does not set an error", func() {
+					Expect(existsErr).ToNot(HaveOccurred())
+				})
+
+				It("does not return a node", func() {
+					Expect(node).To(BeNil())
+				})
+			})
+
+			PContext("there is another reason for the error", func() {
+				BeforeEach(func() {
+					// I need to find a way to do this?
+				})
+
+				It("sets exists to false", func() {
+					Expect(exists).To(BeFalse())
+				})
+
+				It("sets an error", func() {
+					Expect(existsErr).To(HaveOccurred())
+				})
+
+				It("does not return a node", func() {
+					Expect(node).To(BeNil())
+				})
+			})
+		})
+
+		Context("when the node exists", func() {
+			BeforeEach(func() {
+				m.Update(nodeReplacement, func(obj utils.Object) utils.Object {
+					nr, _ := obj.(*navarchosv1alpha1.NodeReplacement)
+					nr.Spec.NodeUID = workerNode1.GetUID()
+					nr.Spec.NodeName = workerNode1.GetName()
+					return nr
+				}, timeout).Should(Succeed())
+			})
+
+			It("sets exists to true", func() {
+				Expect(exists).To(BeTrue())
+			})
+
+			It("does not set an error", func() {
+				Expect(existsErr).ToNot(HaveOccurred())
+			})
+
+			It("returns the node", func() {
+				Expect(node.GetName()).To(Equal(workerNode1.GetName()))
+				Expect(node.GetUID()).To(Equal(workerNode1.GetUID()))
+			})
+		})
+	})
+
+	Context("cordonNode", func() {
+		var err error
+
+		Context("when called on an uncordoned node", func() {
+			JustBeforeEach(func() {
+				err = h.cordonNode(workerNode2)
+			})
+			It("should cordon the node", func() {
+				m.Eventually(workerNode2, timeout).Should(utils.WithField("Spec.Unschedulable", BeTrue()))
+				m.Eventually(workerNode2, timeout).Should(utils.WithField("Spec.Taints",
+					ContainElement(SatisfyAll(
+						utils.WithField("Effect", Equal(corev1.TaintEffect("NoSchedule"))),
+						utils.WithField("Key", Equal("node.kubernetes.io/unschedulable")),
+					)),
+				))
+			})
+
+			It("should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when called on a cordoned node", func() {
+			var cordonedNode *corev1.Node
+			BeforeEach(func() {
+				cordonedNode = utils.ExampleNodeMaster1.DeepCopy()
+				m.Create(cordonedNode).Should(Succeed())
+				m.Update(cordonedNode, func(obj utils.Object) utils.Object {
+					node, _ := obj.(*corev1.Node)
+					node.Spec.Unschedulable = true
+					node, _, _ = taints.AddOrUpdateTaint(node, &corev1.Taint{
+						Key:    "node.kubernetes.io/unschedulable",
+						Effect: corev1.TaintEffect("NoSchedule"),
+					})
+					return node
+				}, timeout).Should(Succeed())
+			})
+
+			It("should cordon the node", func() {
+				m.Consistently(cordonedNode, timeout).Should(utils.WithField("Spec.Unschedulable", BeTrue()))
+				m.Consistently(cordonedNode, timeout).Should(utils.WithField("Spec.Taints",
+					ContainElement(SatisfyAll(
+						utils.WithField("Effect", Equal(corev1.TaintEffect("NoSchedule"))),
+						utils.WithField("Key", Equal("node.kubernetes.io/unschedulable")),
+					)),
+				))
+			})
+
+			It("should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Context("processPods", func() {
+		var nodePods []string
+		var ignoredPods []navarchosv1alpha1.PodReason
+		var daemonset *appsv1.DaemonSet
+
+		var err error
+		BeforeEach(func() {
+			daemonset = utils.ExampleDaemonSet.DeepCopy()
+			m.Create(daemonset).Should(Succeed())
+			m.Update(pod2, func(obj utils.Object) utils.Object {
+				pod, _ := obj.(*corev1.Pod)
+				pod.SetOwnerReferences([]metav1.OwnerReference{utils.GetOwnerReferenceForDaemonSet(daemonset)})
+				return pod
+			}, timeout).Should(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			nodePods, ignoredPods, err = h.processPods(workerNode1)
+		})
+
+		It("sets NodePods", func() {
+			Expect(nodePods).To(ConsistOf(
+				"pod-1",
+				"pod-2",
+				"pod-3",
+			))
+		})
+
+		It("sets IgnoredPods", func() {
+			Expect(ignoredPods).To(ConsistOf(
+				navarchosv1alpha1.PodReason{Name: "pod-2", Reason: "pod owned by a DaemonSet"}))
+		})
+
+		It("should not return an error", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -145,6 +145,11 @@ var ExampleNodeReplacement = &navarchosv1alpha1.NodeReplacement{
 	Status: navarchosv1alpha1.NodeReplacementStatus{
 		Phase: navarchosv1alpha1.ReplacementPhaseNew,
 	},
+	Spec: navarchosv1alpha1.NodeReplacementSpec{
+		ReplacementSpec: navarchosv1alpha1.ReplacementSpec{
+			Priority: intPtr(0),
+		},
+	},
 }
 
 // ExamplePod is an example of a Pod for use in test

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -175,6 +175,10 @@ var ExampleDaemonSet = &appsv1.DaemonSet{
 		Namespace: "default",
 		Labels:    exampleApp,
 	},
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "DaemonSet",
+		APIVersion: "appsv1",
+	},
 	Spec: appsv1.DaemonSetSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: exampleApp,


### PR DESCRIPTION
This PR adds the functionality to handle `NodeReplacement`s in the `New` phase.

To preserve the history:

The failing tests are: 

```
[Fail] Handler suite when the Handler is called on a New NodeReplacement when a pod is owned by a Dea
monSet [It] should ignore the DaemonSet managed Pod
/Users/tb15/go/src/github.com/pusher/navarchos/pkg/controller/nodereplacement/handler/handler_test.go
:284

[Fail] Handler suite when the Handler is called on a New NodeReplacement [It] should list all Pods in
 the Result NodePods field
/Users/tb15/go/src/github.com/pusher/navarchos/pkg/controller/nodereplacement/handler/handler_test.go
:251

[Fail] Handler suite when the Handler is called on a New NodeReplacement if a another NodeReplacement
 is the same priority [It] sets the Result NodePods field to contain a list of pods to evict
/Users/tb15/go/src/github.com/pusher/navarchos/pkg/controller/nodereplacement/handler/handler_test.go
:200

[Fail] Handler suite when the Handler is called on a New NodeReplacement if a another NodeReplacement
 is the same priority [It] sets the Result Phase field to InProgress
/Users/tb15/go/src/github.com/pusher/navarchos/pkg/controller/nodereplacement/handler/handler_test.go
:209
```

They are all failing because results are not being passed through `handleInProgress` to the end `result` returned by `h.Handle()`. I think this could be fixed by changing the tests to `Eventually()` see the change in the `NodeReplacement` status field. 

```
			It("sets the Result NodePods field to contain a list of pods to evict", func() {
				m.Eventually(nodeReplacement, timeout).Should(utils.WithField("Status.NodePods",
					ConsistOf(
						"pod-1",
						"pod-2",
						"pod-3",
					),
				))

			})
```

I'm not too sure how good of a fix this is. It may make reading the tests more difficult, you have to know the instance of the replacement gets modified in place.

Removing the result argument from the `handleInProgress` func means the changes the previous handlers have made are not returned by `h.Handle()` when called. This is because the output of `handleInProgress` is ultimately always what gets returned when calling `h.Handle()` and following the happy path. Currently because `handleInProgress` is not implemented the function returns the result it was passed. 

This does not happen when a requeue is set because the result is returned when its set: 

```
if result.Requeue {
	return result, nil
}
```

Does it even make sense to have an `InProgress` case in the new handler PR? I think I could solve this all by just removing it.  However, would the problem not come back? Does the way we currently test things work with the `fallthrough` model?

