### PR TITLE
Add pod indexer for spec.nodeName

### DIFF
--- a/pkg/apis/navarchos/v1alpha1/nodereplacement_types.go
+++ b/pkg/apis/navarchos/v1alpha1/nodereplacement_types.go
@@ -104,9 +104,18 @@ type PodReason struct {
 type NodeReplacementConditionType string
 
 const (
-	// NodeCordonedType refers to whether the controller successfully managed to
-	// cordon the node.
+	// NodeCordonedType refers to the type of condition where the controller
+	// successfully managed to cordon the node
 	NodeCordonedType NodeReplacementConditionType = "NodeCordoned"
+)
+
+const (
+	// ReasonNodeCordoned refers to whether the controller successfully managed to
+	// cordon the node
+	ReasonNodeCordoned NodeReplacementConditionReason = "NodeCordoned"
+
+	// ReasonErrorCordoningNode is a replacement condition for a failed node cordon
+	ReasonErrorCordoningNode NodeReplacementConditionReason = "ErrorCordoningNode"
 )
 
 // NodeReplacementConditionReason represents a valid condition reason for a NodeReplacement

--- a/pkg/controller/nodereplacement/handler/new.go
+++ b/pkg/controller/nodereplacement/handler/new.go
@@ -38,10 +38,15 @@ func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeRepla
 
 	err = h.cordonNode(node)
 	if err != nil {
-		return &status.Result{}, fmt.Errorf("error cordoning node: %v", err)
+		return &status.Result{
+			NodeCordonError:  err,
+			NodeCordonReason: navarchosv1alpha1.NodeReplacementConditionReason("ErrorCordoningNode"),
+		}, fmt.Errorf("error cordoning node: %v", err)
 	}
 
-	result := &status.Result{}
+	result := &status.Result{
+		NodeCordonReason: navarchosv1alpha1.NodeReplacementConditionReason("NodeCordoned"),
+	}
 	result.NodePods, result.IgnoredPods, err = h.getPodsOnNode(node)
 	if err != nil {
 		return result, fmt.Errorf("error listing pods on node %s: %v", node.GetName(), err)

--- a/pkg/controller/nodereplacement/handler/new.go
+++ b/pkg/controller/nodereplacement/handler/new.go
@@ -38,14 +38,15 @@ func (h *NodeReplacementHandler) handleNew(instance *navarchosv1alpha1.NodeRepla
 
 	err = h.cordonNode(node)
 	if err != nil {
+		// TODO: once migrated to kind, test this case.
 		return &status.Result{
 			NodeCordonError:  err,
-			NodeCordonReason: navarchosv1alpha1.NodeReplacementConditionReason("ErrorCordoningNode"),
+			NodeCordonReason: navarchosv1alpha1.ReasonErrorCordoningNode,
 		}, fmt.Errorf("error cordoning node: %v", err)
 	}
 
 	result := &status.Result{
-		NodeCordonReason: navarchosv1alpha1.NodeReplacementConditionReason("NodeCordoned"),
+		NodeCordonReason: navarchosv1alpha1.ReasonNodeCordoned,
 	}
 	result.NodePods, result.IgnoredPods, err = h.getPodsOnNode(node)
 	if err != nil {

--- a/pkg/controller/nodereplacement/handler/new_test.go
+++ b/pkg/controller/nodereplacement/handler/new_test.go
@@ -387,6 +387,10 @@ var _ = Describe("new node replacement handler", func() {
 			}
 		})
 
+		It("should set the NodeCordonReason to NodeCordoned", func() {
+			Expect(result.NodeCordonReason).To(Equal(navarchosv1alpha1.ReasonNodeCordoned))
+		})
+
 		It("should not return an error", func() {
 			Expect(handleErr).ToNot(HaveOccurred())
 		})

--- a/pkg/controller/nodereplacement/nodereplacement_controller.go
+++ b/pkg/controller/nodereplacement/nodereplacement_controller.go
@@ -24,6 +24,7 @@ import (
 	navarchosv1alpha1 "github.com/pusher/navarchos/pkg/apis/navarchos/v1alpha1"
 	"github.com/pusher/navarchos/pkg/controller/nodereplacement/handler"
 	"github.com/pusher/navarchos/pkg/controller/nodereplacement/status"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,6 +64,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for changes to NodeReplacement
 	err = c.Watch(&source.Kind{Type: &navarchosv1alpha1.NodeReplacement{}}, &watchhandler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	err = mgr.GetCache().IndexField(&corev1.Pod{}, "spec.nodeName", func(obj runtime.Object) []string {
+		pod, _ := obj.(*corev1.Pod)
+		return []string{pod.Spec.NodeName}
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR attempts to fix a bug where the replacement controller can't list the pods on a node: 

```E1010 13:52:24.377899       1 controller.go:218] controller-runtime/controller "msg"="Reconciler error" "error"="error handling replacement ip-10-36-1-75.ec2.internal-b7fcp: error listing pods on node ip-10-36-1-75.ec2.internal: Index with name field:spec.nodeName does not exist"  "controller"="nodereplacement-controller" "request"={"Namespace":"","Name":"ip-10-36-1-75.ec2.internal-b7fcp"}```

