### PR TITLE
Update RBAC generation

### DIFF
--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -25,6 +25,38 @@ rules:
   - update
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - navarchos.pusher.com
   resources:
   - noderollouts

--- a/pkg/controller/nodereplacement/nodereplacement_controller.go
+++ b/pkg/controller/nodereplacement/nodereplacement_controller.go
@@ -84,6 +84,10 @@ type ReconcileNodeReplacement struct {
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=navarchos.pusher.com,resources=nodereplacements,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=navarchos.pusher.com,resources=nodereplacements/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch
 func (r *ReconcileNodeReplacement) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the NodeReplacement instance
 	instance := &navarchosv1alpha1.NodeReplacement{}


### PR DESCRIPTION
Update the RBAC to reflect the permissions required for the node replacement controller to run.