### PR TITLE
[IS-765] - Add cross namespace testing

### DIFF
--- a/pkg/controller/nodereplacement/handler/handler_test.go
+++ b/pkg/controller/nodereplacement/handler/handler_test.go
@@ -141,6 +141,8 @@ var _ = Describe("Handler suite", func() {
 		pod2 = newPod("pod-2", workerNode1)
 		pod3 = newPod("pod-3", workerNode1)
 		pod4 = newPod("pod-4", workerNode2)
+		pod3.ObjectMeta.Namespace = "not-default"
+		pod4.ObjectMeta.Namespace = "not-default"
 		m.Create(pod1).Should(Succeed())
 		m.Create(pod2).Should(Succeed())
 		m.Create(pod3).Should(Succeed())

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -216,3 +216,10 @@ var ExamplePodDisruptionBudget = policyv1beta1.PodDisruptionBudget{
 		},
 	},
 }
+
+// ExampleNamespace is an example namespace for use in tests
+var ExampleNamespace = corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "example-namespace",
+	},
+}


### PR DESCRIPTION
Add pods in different namespaces to the `nodereplacement` handler test suite.