### PR TITLE
Change status updates to modify NodeReplacements in place

### DIFF
--- a/pkg/controller/nodereplacement/handler/handler_test.go
+++ b/pkg/controller/nodereplacement/handler/handler_test.go
@@ -187,6 +187,23 @@ var _ = Describe("Handler suite", func() {
 		close(done)
 	}, 2*timeout.Seconds())
 
+	Context("when the Handler is called on an uninitialised NodeReplacement", func() {
+		Context("with no phase set", func() {
+			BeforeEach(func() {
+				m.Update(nodeReplacement, func(obj utils.Object) utils.Object {
+					nr, _ := obj.(*navarchosv1alpha1.NodeReplacement)
+					nr.Status.Phase = ""
+					return nr
+				}, timeout).Should(Succeed())
+			})
+
+			It("should not return an error", func() {
+				Expect(handleErr).ToNot(HaveOccurred())
+			})
+
+		})
+	})
+
 	Context("when the Handler is called on a New NodeReplacement", func() {
 		Context("if a another NodeReplacement is higher priority", func() {
 			BeforeEach(func() {

--- a/pkg/controller/nodereplacement/status/status.go
+++ b/pkg/controller/nodereplacement/status/status.go
@@ -44,10 +44,9 @@ func UpdateStatus(c client.Client, instance *navarchosv1alpha1.NodeReplacement, 
 	}
 
 	if !reflect.DeepEqual(status, instance.Status) {
-		copy := instance.DeepCopy()
-		copy.Status = status
+		instance.Status = status
 
-		err := c.Update(context.TODO(), copy)
+		err := c.Update(context.TODO(), instance)
 		if err != nil {
 			return fmt.Errorf("error updating status: %v", err)
 		}


### PR DESCRIPTION
This PR fixes a bug where status updates were being attempted on a stale replacement instance. 