### PR TITLE
Fix NodeReplacement requeue logic

### DIFF
--- a/pkg/controller/nodereplacement/handler/new.go
+++ b/pkg/controller/nodereplacement/handler/new.go
@@ -71,6 +71,9 @@ func (h *NodeReplacementHandler) shouldRequeueReplacement(instance *navarchosv1a
 	}
 
 	for _, replacement := range replacements.Items {
+		if replacement.Status.Phase == navarchosv1alpha1.ReplacementPhaseCompleted {
+			continue
+		}
 		if *replacement.Spec.ReplacementSpec.Priority > *instance.Spec.ReplacementSpec.Priority {
 			reason := fmt.Sprintf("NodeReplacement \"%s\" has a higher priority", replacement.GetName())
 			return true, reason

--- a/pkg/controller/nodereplacement/nodereplacement_controller.go
+++ b/pkg/controller/nodereplacement/nodereplacement_controller.go
@@ -125,6 +125,12 @@ func (r *ReconcileNodeReplacement) Reconcile(request reconcile.Request) (reconci
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("error updating status: %v", err)
 	}
+	if result.Requeue {
+		log.Printf("requeueing replacement %s: %s", instance.GetName(), result.RequeueReason)
+		return reconcile.Result{
+			Requeue: true,
+		}, nil
+	}
 
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
Up until now the requeue logic in the `NodeReplacement` controller was flawed. Now when the `requeue` flag is set in a result the reconcile loop will actually requeue the replacement. 

The helper func `shouldRequeueReplacement` will now ignore completed replacements of a higher priority as well. This stops replacements of a lower priority from not being processed.