### PR TITLE
Update RBAC to allow emitting events

### DIFF
--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -49,6 +49,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - patch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/pkg/controller/nodereplacement/nodereplacement_controller.go
+++ b/pkg/controller/nodereplacement/nodereplacement_controller.go
@@ -101,6 +101,7 @@ type ReconcileNodeReplacement struct {
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=patch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch
 func (r *ReconcileNodeReplacement) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the NodeReplacement instance


### PR DESCRIPTION
This PR adds the required RBAC permissions to allow the `NodeReplacement` controller to emit events.