### PR TITLE
[IS-798] - Add node replacement printer columns

### DIFF
--- a/config/crds/navarchos_v1alpha1_nodereplacement.yaml
+++ b/config/crds/navarchos_v1alpha1_nodereplacement.yaml
@@ -6,6 +6,34 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: nodereplacements.navarchos.pusher.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.nodePodsCount
+    description: Number of pods on the node
+    name: Node Pods
+    type: integer
+  - JSONPath: .status.ignoredPodsCount
+    description: Number of pods ignored
+    name: Ignored Pods
+    type: integer
+  - JSONPath: .status.evictedPodsCount
+    description: Number of pods evicted
+    name: Evicted Pods
+    type: integer
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  - JSONPath: .spec.replacement.priority
+    description: The priority of the replacement
+    name: Priority
+    priority: 1
+    type: integer
+  - JSONPath: .status.completionTimestamp
+    description: The time since the replacement completed
+    name: Completed
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: navarchos.pusher.com
   names:
     kind: NodeReplacement

--- a/pkg/apis/navarchos/v1alpha1/nodereplacement_types.go
+++ b/pkg/apis/navarchos/v1alpha1/nodereplacement_types.go
@@ -149,6 +149,13 @@ type NodeReplacementCondition struct {
 // NodeReplacement is the Schema for the nodereplacements API
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=nodereplacements,shortName=nrep;nreps;nrp;nrps
+// +kubebuilder:printcolumn:name="Node Pods",type="integer",JSONPath=".status.nodePodsCount",description="Number of pods on the node"
+// +kubebuilder:printcolumn:name="Ignored Pods",type="integer",JSONPath=".status.ignoredPodsCount",description="Number of pods ignored"
+// +kubebuilder:printcolumn:name="Evicted Pods",type="integer",JSONPath=".status.evictedPodsCount",description="Number of pods evicted"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Priority",type="integer",JSONPath=".spec.replacement.priority",description="The priority of the replacement",priority="1"
+// +kubebuilder:printcolumn:name="Completed",type="date",JSONPath=".status.completionTimestamp",description="The time since the replacement completed"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type NodeReplacement struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This PR adds additional columns to the `NodeReplacement` type: 

- NodePods
- Evicted pods
- IgnoredPods
- CreatedTimestamp
- CompletedTimestamp

This should allow a user of Navarchos to more easily track the progress of a `NodeReplacement`

