### PR TITLE
Set Eviction Grace Period to infinite (-1)

### DIFF
--- a/pkg/controller/nodereplacement/handler/handler.go
+++ b/pkg/controller/nodereplacement/handler/handler.go
@@ -46,7 +46,7 @@ type Options struct {
 // Complete defaults any values that are not explicitly set
 func (o *Options) Complete() {
 	if o.EvictionGracePeriod == nil {
-		grace := 30 * time.Second
+		grace := -1 * time.Second
 		o.EvictionGracePeriod = &grace
 	}
 	if o.DrainTimeout == nil {


### PR DESCRIPTION
When the eviction grace period is set to a duration non-infinite, the pod will be deleted after that time no matter if it has gracefully terminated itself or not.

By default, Kubectl drain set's this to `-1` which means the Pod is allowed to stick around until it has gracefully terminated itself, which is desirable when we have large numbers of pods which set longer graceful drain periods