### PR TITLE
[IS-817] - Check if any pods are pending before starting the next NodeReplacement

### DIFF
--- a/pkg/controller/nodereplacement/handler/new.go
+++ b/pkg/controller/nodereplacement/handler/new.go
@@ -84,6 +84,19 @@ func (h *NodeReplacementHandler) shouldRequeueReplacement(instance *navarchosv1a
 		}
 	}
 
+	pods := corev1.PodList{}
+	err = h.client.List(context.Background(), &pods, client.MatchingFields{"status.phase": "Pending"})
+	if err != nil {
+		return true, fmt.Sprintf("failed to list pending pods: %v", err)
+	}
+	if len(pods.Items) != 0 {
+		podNames := []string{}
+		for _, pod := range pods.Items {
+			podNames = append(podNames, pod.GetName())
+		}
+		return true, fmt.Sprintf("requeuing as there are pending pod(s): %v", podNames)
+	}
+
 	return false, ""
 }
 

--- a/pkg/controller/nodereplacement/handler/new_test.go
+++ b/pkg/controller/nodereplacement/handler/new_test.go
@@ -49,6 +49,12 @@ var _ = Describe("new node replacement handler", func() {
 		return pod
 	}
 
+	var setPodPending = func(obj utils.Object) utils.Object {
+		pod, _ := obj.(*corev1.Pod)
+		pod.Status.Phase = corev1.PodPending
+		return pod
+	}
+
 	var setPodSucceeded = func(obj utils.Object) utils.Object {
 		pod, _ := obj.(*corev1.Pod)
 		pod.Status.Phase = corev1.PodSucceeded
@@ -190,6 +196,20 @@ var _ = Describe("new node replacement handler", func() {
 
 			It("requeues the NodeReplacement", func() {
 				Expect(reason).To(Equal("NodeReplacement \"in-progress\" is already in-progress"))
+			})
+		})
+
+		Context("if a pod is pending", func() {
+			BeforeEach(func() {
+				m.UpdateStatus(pod1, setPodPending, timeout).Should(Succeed())
+			})
+
+			It("sets requeue to true", func() {
+				Expect(requeue).To(BeTrue())
+			})
+
+			It("requeues the NodeReplacement", func() {
+				Expect(reason).To(Equal("requeuing as there are pending pod(s): [pod-1]"))
 			})
 		})
 

--- a/pkg/controller/nodereplacement/nodereplacement_controller.go
+++ b/pkg/controller/nodereplacement/nodereplacement_controller.go
@@ -77,7 +77,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return []string{pod.Spec.NodeName}
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to add pod spec.nodeName indexer: %s", err.Error())
+	}
+
+	err = mgr.GetCache().IndexField(&corev1.Pod{}, "status.phase", func(obj runtime.Object) []string {
+		pod, _ := obj.(*corev1.Pod)
+		return []string{string(pod.Status.Phase)}
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add pod phase indexer: %s", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
"As a user of Navarchos I should be able to trust the tool to not break a cluster, so I can use it with peace of mind"

"As a cluster operator I don't want an automation process to continue if there is potentially a problem, so I can intervene if the problem would be serious / compound to be a large issue"

When relying on the cluster autoscaler this should mean there is less churn. 